### PR TITLE
builder: do not hash cache keys

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1,7 +1,6 @@
 package builder
 
 import (
-	"crypto/sha512"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -99,8 +98,7 @@ func (b *Builder) AddVerb(name string, fn verbFunc, args mruby.ArgSpec) {
 		args := m.GetArgs()
 		strArgs := extractStringArgs(args)
 		cacheKey := strings.Join(append([]string{name}, strArgs...), ", ")
-		sum := sha512.Sum512_256([]byte(cacheKey))
-		cacheKey = base64.StdEncoding.EncodeToString([]byte(sum[:]))
+		cacheKey = base64.StdEncoding.EncodeToString([]byte(cacheKey))
 
 		log.BuildStep(name, strings.Join(strArgs, ", "))
 


### PR DESCRIPTION
Since they are a part of the command, a duplicate hash provided by a different
command has the potential to corrupt the cache accidentally.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>