### PR TITLE
builder: better signal handling

### DIFF
--- a/builder/signal/signal.go
+++ b/builder/signal/signal.go
@@ -1,0 +1,36 @@
+package signal
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+var currentChannel chan os.Signal
+
+// SetSignal It handles INT and TERM signals. If a hook is provided, it will be
+// run at signal handling time, before terminating the program.
+//
+// This is not threadsafe code.
+func SetSignal(hook func()) {
+	intSig := make(chan os.Signal)
+	signal.Notify(intSig, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		_, ok := <-intSig
+		if ok {
+			if hook != nil {
+				hook()
+			}
+
+			fmt.Println("\n\n!!! SIGINT or SIGTERM recieved, crashing container...")
+			os.Exit(1)
+		}
+	}()
+
+	if currentChannel != nil {
+		signal.Stop(currentChannel)
+	}
+
+	currentChannel = intSig
+}

--- a/cli-tests/basic_test.go
+++ b/cli-tests/basic_test.go
@@ -63,7 +63,7 @@ func (s *cliSuite) TestOmit(c *C) {
 	c.Assert(err, IsNil)
 	checkFailure(c, cmd)
 
-	c.Assert(cmd.Stdout(), Equals, "!!! Error: undefined method 'from' for main\n")
+	c.Assert(cmd.Stdout(), Equals, "\n\n!!! Error: undefined method 'from' for main\n")
 }
 
 func (s *cliSuite) TestTag(c *C) {

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func main() {
 		}
 
 		if err != nil {
-			fmt.Printf("!!! Error: %v\n", err.Error())
+			fmt.Printf("\n\n!!! Error: %v\n", err.Error())
 			os.Exit(2)
 		}
 
@@ -135,7 +135,7 @@ func main() {
 
 		response, err := b.Run(string(content))
 		if err != nil {
-			fmt.Printf("!!! Error: %v\n", err.Error())
+			fmt.Printf("\n\n!!! Error: %v\n", err.Error())
 			os.Exit(1)
 		}
 
@@ -163,7 +163,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "!!! Error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "\n\n!!! Error: %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -171,10 +171,12 @@ func main() {
 func runRepl(ctx *cli.Context) {
 	r, err := repl.NewRepl()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "!!! Error bootstrapping repl: %v\n", err)
+		fmt.Fprintf(os.Stderr, "\n\n!!! Error bootstrapping repl: %v\n", err)
 		os.Exit(1)
 	}
 
 	if err := r.Loop(); err != nil {
+		fmt.Printf("\n\n!!! Error: %v\n", err)
+		os.Exit(1)
 	}
 }

--- a/tar/tar.go
+++ b/tar/tar.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/erikh/box/builder/signal"
 	"github.com/erikh/box/log"
 )
 
@@ -25,6 +26,9 @@ func Archive(rel, target string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	signal.SetSignal(func() { os.Remove(f.Name()) })
+	defer signal.SetSignal(nil)
 
 	tw := tar.NewWriter(f)
 


### PR DESCRIPTION
This introduces a package called `builder/signal`, which implements generic
signal handling with hooks. Installed hooks in several places to perform
cleanup.

Fixes #49 

Signed-off-by: Erik Hollensbe <github@hollensbe.org>