### PR TITLE
builder: correct a number of issues with cmd/entrypoint:

### DIFF
--- a/builder/config/config.go
+++ b/builder/config/config.go
@@ -7,15 +7,24 @@ import (
 	"github.com/docker/docker/api/types/container"
 )
 
+// CommandState is an abstraction to facilitate Cmd and Entrypoint handling and
+// inheritance. It is split so that the docker configuration can use it as
+// needed to provide temporary build-time instructions vs. image-level
+// instructions. See ToDocker() for code that uses this struct.
+type CommandState struct {
+	Temporary []string
+	Image     []string
+}
+
 // Config is a basic configuration of an image at each step. It is kept in sync
 // by commit routines in the executor. Setting properties here will propogate
 // them to various image-manipulating commands when needed.
 type Config struct {
-	Image      string   // Image Identifier, may be different across executors.
-	User       string   // the currently configured user for this image.
-	WorkDir    string   // the current working directory on entering a container
-	Cmd        []string // the secondary execution form, it is provided to images if given to docker run, otherwise this is used.
-	Entrypoint []string // the primary execution form, the first arguments and the exec() jumping-off point.
+	Image      string       // Image Identifier, may be different across executors.
+	User       string       // the currently configured user for this image.
+	WorkDir    string       // the current working directory on entering a container
+	Cmd        CommandState // the secondary execution form, it is provided to images if given to docker run, otherwise this is used.
+	Entrypoint CommandState // the primary execution form, the first arguments and the exec() jumping-off point.
 	Env        []string
 }
 
@@ -23,15 +32,35 @@ type Config struct {
 func NewConfig() *Config {
 	return &Config{
 		Env:     []string{},
-		Cmd:     []string{"/bin/sh"},
 		User:    "root",
 		WorkDir: "/",
 		Image:   "",
 	}
 }
 
+// TemporaryCommand is used to manage run and debug statements and similar
+// effects where the results should not be recorded in the committed container.
+func (c *Config) TemporaryCommand(entrypoint, cmd []string) {
+	c.Entrypoint.Temporary = entrypoint
+	c.Cmd.Temporary = cmd
+}
+
 // ToDocker outputs a docker configuration suitable for running images.
-func (c *Config) ToDocker(tty, stdin bool) *container.Config {
+func (c *Config) ToDocker(temporary, tty, stdin bool) *container.Config {
+	var cmd, entrypoint []string
+
+	if temporary {
+		cmd = c.Cmd.Temporary
+		entrypoint = c.Entrypoint.Temporary
+	} else {
+		cmd = c.Cmd.Image
+		entrypoint = c.Entrypoint.Image
+	}
+
+	if len(cmd) == 0 && len(entrypoint) == 0 {
+		cmd = []string{"/bin/sh"}
+	}
+
 	return &container.Config{
 		Tty:          tty,
 		AttachStderr: true,
@@ -40,8 +69,8 @@ func (c *Config) ToDocker(tty, stdin bool) *container.Config {
 		OpenStdin:    stdin,
 		Image:        c.Image,
 		Env:          c.Env,
-		Entrypoint:   c.Entrypoint,
-		Cmd:          c.Cmd,
+		Entrypoint:   entrypoint,
+		Cmd:          cmd,
 		User:         c.User,
 		WorkingDir:   c.WorkDir,
 	}
@@ -51,8 +80,8 @@ func (c *Config) ToDocker(tty, stdin bool) *container.Config {
 func (c *Config) FromDocker(cont *container.Config) {
 	c.Image = cont.Image
 	c.Env = cont.Env
-	c.Entrypoint = cont.Entrypoint
-	c.Cmd = cont.Cmd
+	c.Entrypoint.Image = cont.Entrypoint
+	c.Cmd.Image = cont.Cmd
 	c.User = cont.User
 	c.WorkDir = cont.WorkingDir
 }
@@ -65,7 +94,7 @@ func (c *Config) ToImage(layers []string) map[string]interface{} {
 	}
 
 	fields := map[string]interface{}{}
-	fields["config"] = c.ToDocker(false, false)
+	fields["config"] = c.ToDocker(false, false, false)
 	fields["created"] = time.Now().Format("2006-01-02T15:04:05Z07:00")
 	fields["architecture"] = "amd64"
 	fields["os"] = "linux"

--- a/builder/executor/docker/docker.go
+++ b/builder/executor/docker/docker.go
@@ -250,7 +250,7 @@ func (d *Docker) Commit(cacheKey string, hook executor.Hook) error {
 		}
 	}
 
-	commitResp, err := d.client.ContainerCommit(context.Background(), id, types.ContainerCommitOptions{Config: d.config.ToDocker(d.tty, d.stdin), Comment: cacheKey})
+	commitResp, err := d.client.ContainerCommit(context.Background(), id, types.ContainerCommitOptions{Config: d.config.ToDocker(false, d.tty, d.stdin), Comment: cacheKey})
 	if err != nil {
 		return fmt.Errorf("Error during commit: %v", err)
 	}
@@ -341,7 +341,7 @@ func (d *Docker) CopyOneFileFromContainer(fn string) ([]byte, error) {
 func (d *Docker) Create() (string, error) {
 	cont, err := d.client.ContainerCreate(
 		context.Background(),
-		d.config.ToDocker(d.tty, d.stdin),
+		d.config.ToDocker(true, d.tty, d.stdin),
 		nil,
 		nil,
 		"",

--- a/builder/executor/docker/docker_run_test.go
+++ b/builder/executor/docker/docker_run_test.go
@@ -36,8 +36,8 @@ func (ds *dockerSuite) TestRunHook(c *C) {
 	id, err := d.Fetch("debian:latest")
 	c.Assert(err, IsNil)
 
-	d.config.Entrypoint = []string{"/bin/sh", "-c"}
-	d.config.Cmd = []string{"exit 0"}
+	d.config.Entrypoint.Temporary = []string{"/bin/sh", "-c"}
+	d.config.Cmd.Temporary = []string{"exit 0"}
 	c.Assert(d.Commit("test", d.RunHook), IsNil)
 	c.Assert(d.config.Image, Not(Equals), id)
 
@@ -50,8 +50,8 @@ func (ds *dockerSuite) TestRunHook(c *C) {
 	c.Assert(err, IsNil)
 	defer d.Destroy(createID)
 
-	d.config.Entrypoint = []string{"/bin/sh", "-c"}
-	d.config.Cmd = []string{"exit 1"}
+	d.config.Entrypoint.Temporary = []string{"/bin/sh", "-c"}
+	d.config.Cmd.Temporary = []string{"exit 1"}
 	c.Assert(d.Commit("test", d.RunHook), NotNil)
 	c.Assert(d.config.Image, Equals, id)
 }

--- a/builder/util_test.go
+++ b/builder/util_test.go
@@ -8,9 +8,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/pkg/term"
-	"github.com/docker/docker/api/types"
 )
 
 func runBuilder(script string) (*Builder, error) {
@@ -28,8 +28,8 @@ func readContainerFile(c *C, b *Builder, fn string) []byte {
 }
 
 func runContainerCommand(c *C, b *Builder, cmd []string) []byte {
-	b.exec.Config().Entrypoint = []string{}
-	b.exec.Config().Cmd = cmd
+	b.exec.Config().Entrypoint.Temporary = []string{}
+	b.exec.Config().Cmd.Temporary = cmd
 	id, err := b.exec.Create()
 	c.Assert(err, IsNil)
 	resp, err := dockerClient.ContainerAttach(context.Background(), id, types.ContainerAttachOptions{Stream: true, Stdout: true, Stdin: true})

--- a/docs/user-guide/verbs.md
+++ b/docs/user-guide/verbs.md
@@ -25,8 +25,7 @@ run "chown -R erikh:erikh /test" # this will run after you close the shell
 ```
 
 ## set\_exec
-`set_exec` sets both the entrypoint and cmd at the same time, allowing for no
-race between the operations.
+`set_exec` sets both the entrypoint and cmd at the same time.
 
 `set_exec` takes a dictionary consisting of two known elements as symbols:
 entrypoint and cmd. They each take a string array which is then propagated
@@ -118,7 +117,7 @@ tag "erikh/true" # tag the latest image as "erikh/true"
 ## entrypoint
 
 entrypoint sets the entrypoint for the image at runtime. It will not be
-used for run invocations. Note that setting this clears any previously set cmd.
+used for run invocations.
 
 Example:
 
@@ -264,8 +263,6 @@ env GOPATH: "/go", PATH: "/usr/bin:/bin" # equivalent if you prefer this syntax
 cmd, when provided with a string will set the docker image's Cmd property,
 which are the arguments that follow the entrypoint (and are overridden when
 you provide a command to `docker run`). It does not affect run invocations.
-
-Note that if you set this before entrypoint, it will be cleared.
 
 Example:
 


### PR DESCRIPTION
* New state management tracks temporary needs and inheritance alongside each
  other to separate powers, making it much easier to track state within the
  application itself.

the result of this is:
  * no longer clears cmd when entrypoint is used
  * inheritance works properly every time
  * code is much cleaner

Signed-off-by: Erik Hollensbe <github@hollensbe.org>

Fixes #56 