### PR TITLE
Turn off gc

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/erikh/box",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v74",
+	"GodepVersion": "v75",
 	"Packages": [
 		"./..."
 	],
@@ -165,7 +165,7 @@
 		},
 		{
 			"ImportPath": "github.com/mitchellh/go-mruby",
-			"Rev": "2b3cb1143d87912a136c0323b1903e1275c37020"
+			"Rev": "7db4b502a0b30326184a5a544e6ceda273aaa044"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/user",

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -52,6 +52,8 @@ func NewBuilder(tty bool, omitFuncs []string) (*Builder, error) {
 		finalCommit: true,
 	}
 
+	builder.mrb.DisableGC()
+
 	for name, def := range verbJumpTable {
 		if keep(omitFuncs, name) {
 			builder.AddVerb(name, def.verbFunc, def.argSpec)
@@ -169,6 +171,8 @@ func (b *Builder) Run(script string) (*mruby.MrbValue, error) {
 
 // Close tears down all functions of the builder, preparing it for exit.
 func (b *Builder) Close() error {
+	b.mrb.EnableGC()
+	b.mrb.FullGC()
 	b.mrb.Close()
 	return nil
 }

--- a/vendor/github.com/mitchellh/go-mruby/README.md
+++ b/vendor/github.com/mitchellh/go-mruby/README.md
@@ -38,6 +38,9 @@ Compiling/installing the go-mruby library should work on Linux, Mac OS X,
 and Windows. On Windows, msys is the only supported build toolchain (same
 as Go itself).
 
+**Due to this linking, it is strongly recommended that you vendor this
+repository and bake our build system into your process.**
+
 ### Customizing the mruby Compilation
 
 You can customize the mruby compilation by setting a couple environmental

--- a/vendor/github.com/mitchellh/go-mruby/mruby.go
+++ b/vendor/github.com/mitchellh/go-mruby/mruby.go
@@ -61,7 +61,24 @@ func (m *Mrb) ArenaSave() ArenaIndex {
 	return ArenaIndex(C.mrb_gc_arena_save(m.state))
 }
 
-// Class returns the class with the given name and superclass. Note that
+// EnableGC enables the garbage collector for this mruby instance. It returns
+// true if garbage collection was previously disabled.
+func (m *Mrb) EnableGC() {
+	C._go_enable_gc(m.state)
+}
+
+// DisableGC disables the garbage collector for this mruby instance. It returns
+// true if it was previously disabled.
+func (m *Mrb) DisableGC() {
+	C._go_disable_gc(m.state)
+}
+
+// LiveObjectCount returns the number of objects that have not been collected (aka, alive).
+func (m *Mrb) LiveObjectCount() int {
+	return int(C._go_gc_live(m.state))
+}
+
+// Class returns the class with the kgiven name and superclass. Note that
 // if you call this with a class that doesn't exist, mruby will abort the
 // application (like a panic, but not a Go panic).
 //

--- a/vendor/github.com/mitchellh/go-mruby/value.go
+++ b/vendor/github.com/mitchellh/go-mruby/value.go
@@ -111,7 +111,7 @@ func (v *MrbValue) call(method string, args []Value, block Value) (*MrbValue, er
 
 // IsDead tells you if an object has been collected by the GC or not.
 func (v *MrbValue) IsDead() bool {
-	return C.ushort(C.mrb_object_dead_p(v.state, C._go_mrb_basic_ptr(v.value))) != 0
+	return C.ushort(C._go_isdead(v.state, v.value)) != 0
 }
 
 // MrbValue so that *MrbValue implements the "Value" interface.
@@ -122,6 +122,11 @@ func (v *MrbValue) MrbValue(*Mrb) *MrbValue {
 // Mrb returns the Mrb state for this value.
 func (v *MrbValue) Mrb() *Mrb {
 	return &Mrb{v.state}
+}
+
+// GCProtect protects this value from being garbage collected.
+func (v *MrbValue) GCProtect() {
+	C.mrb_gc_protect(v.state, v.value)
 }
 
 // SetProcTargetClass sets the target class where a proc will be executed


### PR DESCRIPTION
This turns off gc so that functions will no longer accidentally access dead objects. This is a temporary measure until go-mruby's API supports measures to detect if an object is dead safely before converting it to a given type.