### PR TITLE
Remove final commit

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -29,13 +29,10 @@ skip do
   run "rm #{docker_path}"
   copy "dind", "/dind"
 
-  copy ".", "/go/src/github.com/erikh/box"
-
-  if getenv("IGNORE_LIBMRUBY") == ""
-    run "cd /go/src/github.com/erikh/box && make clean all"
-  end
-
   run "pip install mkdocs mkdocs-bootswatch"
+
+  copy ".", "/go/src/github.com/erikh/box"
+  run "cd /go/src/github.com/erikh/box && make clean all"
 
   workdir "/go/src/github.com/erikh/box"
   set_exec entrypoint: ["/dind"], cmd: ["make", "docker-test"]

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -140,19 +140,6 @@ func (b *Builder) Run(script string) (*mruby.MrbValue, error) {
 
 	defer b.exec.Destroy(id)
 
-	// this tweaks the behavior to be a little more consisitent IMO with regards
-	// to how docker handles inheritance. It's a hack and a very non-standard
-	// part of box. This also slightly forces users to consider the users and
-	// paths involved in running their images, which I think is a good thing.
-
-	if b.exec.Config().WorkDir == "" { // if the working dir is empty, set to / -- don't inherit.
-		b.exec.Config().WorkDir = "/"
-	}
-
-	if b.exec.Config().User == "" { // if the user is empty, do not inherit; use root.
-		b.exec.Config().User = "root"
-	}
-
 	if err := b.exec.MakeImage(); err != nil {
 		return nil, err
 	}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -16,11 +16,10 @@ import (
 
 // Builder implements the builder core.
 type Builder struct {
-	useCache    bool
-	mrb         *mruby.Mrb
-	exec        executor.Executor
-	fromImage   string
-	finalCommit bool
+	useCache  bool
+	mrb       *mruby.Mrb
+	exec      executor.Executor
+	fromImage string
 }
 
 func keep(omitFuncs []string, name string) bool {
@@ -46,10 +45,9 @@ func NewBuilder(tty bool, omitFuncs []string) (*Builder, error) {
 	}
 
 	builder := &Builder{
-		useCache:    useCache,
-		mrb:         mruby.NewMrb(),
-		exec:        exec,
-		finalCommit: true,
+		useCache: useCache,
+		mrb:      mruby.NewMrb(),
+		exec:     exec,
 	}
 
 	builder.mrb.DisableGC()
@@ -123,13 +121,6 @@ func (b *Builder) AddVerb(name string, fn verbFunc, args mruby.ArgSpec) {
 	b.mrb.TopSelf().SingletonClass().DefineMethod(name, builderFunc, args)
 }
 
-// FinalCommit instructs the builder to perform the final commit at builder
-// termination time. This, however, should not happen if instructed not to or
-// in cases where the builder may be paused e.g., the repl.
-func (b *Builder) FinalCommit(ok bool) {
-	b.finalCommit = ok
-}
-
 // Run the script.
 func (b *Builder) Run(script string) (*mruby.MrbValue, error) {
 	if _, err := b.mrb.LoadString(script); err != nil {
@@ -158,12 +149,6 @@ func (b *Builder) Run(script string) (*mruby.MrbValue, error) {
 
 	if err := b.exec.MakeImage(); err != nil {
 		return nil, err
-	}
-
-	if b.finalCommit {
-		if err := b.exec.Commit("", nil); err != nil {
-			return nil, err
-		}
 	}
 
 	return mruby.String(b.exec.ImageID()).MrbValue(b.mrb), nil

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -104,6 +105,11 @@ func (b *Builder) AddVerb(name string, fn verbFunc, args mruby.ArgSpec) {
 		cacheKey = base64.StdEncoding.EncodeToString([]byte(cacheKey))
 
 		log.BuildStep(name, strings.Join(strArgs, ", "))
+
+		if os.Getenv("BOX_DEBUG") != "" {
+			content, _ := json.MarshalIndent(b.exec.Config(), "", "  ")
+			fmt.Println(string(content))
+		}
 
 		cached, err := b.exec.CheckCache(cacheKey)
 		if err != nil {

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -477,13 +477,11 @@ func (bs *builderSuite) TestBuildCache(c *C) {
 
 	b, err := runBuilder(`
     from "debian"
-    run "true"
   `)
 
 	c.Assert(err, IsNil)
 
-	imageID, err := getParent(b, b.exec.Config().Image)
-	c.Assert(err, IsNil)
+	imageID := b.exec.Config().Image
 	b.Close()
 
 	b, err = runBuilder(fmt.Sprintf(`
@@ -493,8 +491,7 @@ func (bs *builderSuite) TestBuildCache(c *C) {
 
 	c.Assert(err, IsNil)
 
-	cached, err := getParent(b, b.exec.Config().Image)
-	c.Assert(err, IsNil)
+	cached := b.exec.Config().Image
 	b.Close()
 
 	b, err = runBuilder(fmt.Sprintf(`
@@ -503,9 +500,7 @@ func (bs *builderSuite) TestBuildCache(c *C) {
   `, imageID))
 
 	c.Assert(err, IsNil)
-	parent, err := getParent(b, b.exec.Config().Image)
-	c.Assert(err, IsNil)
-	c.Assert(cached, Equals, parent)
+	c.Assert(cached, Equals, b.exec.Config().Image)
 	b.Close()
 
 	b, err = runBuilder(fmt.Sprintf(`
@@ -514,9 +509,7 @@ func (bs *builderSuite) TestBuildCache(c *C) {
   `, imageID))
 
 	c.Assert(err, IsNil)
-	parent, err = getParent(b, b.exec.Config().Image)
-	c.Assert(err, IsNil)
-	c.Assert(cached, Not(Equals), parent)
+	c.Assert(cached, Not(Equals), b.exec.Config().Image)
 	b.Close()
 
 	b, err = runBuilder(fmt.Sprintf(`
@@ -526,19 +519,16 @@ func (bs *builderSuite) TestBuildCache(c *C) {
 
 	c.Assert(err, IsNil)
 
-	cached, err = getParent(b, b.exec.Config().Image)
-	c.Assert(err, IsNil)
+	cached = b.exec.Config().Image
 	b.Close()
 
 	b, err = runBuilder(fmt.Sprintf(`
     from "%s"
     copy ".", "."
   `, imageID))
+	c.Assert(err, IsNil)
 
-	c.Assert(err, IsNil)
-	parent, err = getParent(b, b.exec.Config().Image)
-	c.Assert(err, IsNil)
-	c.Assert(cached, Equals, parent)
+	c.Assert(cached, Equals, b.exec.Config().Image)
 
 	f, err := os.Create("test")
 	c.Assert(err, IsNil)
@@ -552,9 +542,7 @@ func (bs *builderSuite) TestBuildCache(c *C) {
   `, imageID))
 
 	c.Assert(err, IsNil)
-	parent, err = getParent(b, b.exec.Config().Image)
-	c.Assert(err, IsNil)
-	c.Assert(cached, Not(Equals), parent)
+	c.Assert(cached, Not(Equals), b.exec.Config().Image)
 	b.Close()
 }
 

--- a/main.go
+++ b/main.go
@@ -69,10 +69,6 @@ func main() {
 			Name:  "omit, o",
 			Usage: "Omit functions/verbs. One per option, repeatable.",
 		},
-		cli.BoolFlag{
-			Name:  "no-final-commit, f",
-			Usage: "Perform no automatic commit at the end of the run.",
-		},
 	}
 
 	app.Commands = []cli.Command{
@@ -111,8 +107,6 @@ func main() {
 			panic(err)
 		}
 		defer b.Close()
-
-		b.FinalCommit(!ctx.Bool("no-final-commit"))
 
 		var content []byte
 

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -31,8 +31,6 @@ func NewRepl() (*Repl, error) {
 		return nil, err
 	}
 
-	b.FinalCommit(false)
-
 	return &Repl{readline: rl, builder: b}, nil
 }
 


### PR DESCRIPTION
builder,main.go,repl: Remove final commit logic from the code.
    
This behavior was the cause of a lot of confusion around the design and
implementation of the builder itself. It lead to more problems than it solved
and was largely a workaround for the problems with state fixed in
0de072a9004c113e9b1d2b87471345e902b9399e.
    
