### PR TITLE
builder: fix copy routines that used relative paths with workdir.

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -81,6 +81,16 @@ func (bs *builderSuite) TestCopyToRelativePathWithWorkdir(c *C) {
   `)
 	c.Assert(err, IsNil)
 	b.Close()
+
+	b, err = runBuilder(`
+    from "debian"
+    run "mkdir /test"
+    workdir "/test"
+    copy "config", "."
+    run "test -f /test/config/config.go"
+  `)
+	c.Assert(err, IsNil)
+	b.Close()
 }
 
 func (bs *builderSuite) TestCopy(c *C) {
@@ -90,7 +100,6 @@ func (bs *builderSuite) TestCopy(c *C) {
     from "debian"
     copy "%s", "/test1.rb"
   `, testpath))
-
 	c.Assert(err, IsNil)
 
 	result := readContainerFile(c, b, "/test1.rb")

--- a/builder/config/config.go
+++ b/builder/config/config.go
@@ -36,7 +36,7 @@ type Config struct {
 func NewConfig() *Config {
 	return &Config{
 		Env:     []string{},
-		User:    StringState{"root", "root"},
+		User:    StringState{"", "root"},
 		WorkDir: StringState{"", "/"},
 		Image:   "",
 	}

--- a/builder/util_test.go
+++ b/builder/util_test.go
@@ -48,7 +48,7 @@ func runContainerCommand(c *C, b *Builder, cmd []string) []byte {
 		n, err = stdcopy.StdCopy(buf, buf, resp.Reader)
 	}
 
-	c.Assert(err, IsNil)
+	c.Assert(err, IsNil, Commentf("%v", err))
 	c.Assert(n, Not(Equals), 0)
 
 	nr := bufio.NewReader(buf)
@@ -66,7 +66,7 @@ func runContainerCommand(c *C, b *Builder, cmd []string) []byte {
 
 	status, err := dockerClient.ContainerWait(context.Background(), id)
 	c.Assert(err, IsNil)
-	c.Assert(status, Equals, 0)
+	c.Assert(status, Equals, 0, Commentf("%v", result))
 
 	return result
 }


### PR DESCRIPTION
Signed-off-by: Erik Hollensbe <github@hollensbe.org>