### PR TITLE
builder,docs: fix copy semantics

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -93,6 +93,23 @@ func (bs *builderSuite) TestCopyToRelativePathWithWorkdir(c *C) {
 	b.Close()
 }
 
+func (bs *builderSuite) TestCopyOverDir(c *C) {
+	testpath := filepath.Join(dockerfilePath, "test1.rb")
+
+	_, err := runBuilder(fmt.Sprintf(`
+    from "debian"
+    copy "%s", "/tmp"
+  `, testpath))
+	c.Assert(err, NotNil)
+
+	_, err = runBuilder(fmt.Sprintf(`
+    from "debian"
+    copy "%s", "/tmp/"
+    run "test -f /tmp/test1.rb"
+  `, testpath))
+	c.Assert(err, IsNil)
+}
+
 func (bs *builderSuite) TestCopy(c *C) {
 	testpath := filepath.Join(dockerfilePath, "test1.rb")
 

--- a/builder/executor/docker/docker.go
+++ b/builder/executor/docker/docker.go
@@ -261,7 +261,7 @@ func (d *Docker) CopyFromContainer(id, path string) (io.Reader, int64, error) {
 // containerto the container so it can then be committed. It does not close the
 // reader.
 func (d *Docker) CopyToContainer(id string, r io.Reader) error {
-	return d.client.CopyToContainer(context.Background(), id, "/", r, types.CopyToContainerOptions{AllowOverwriteDirWithFile: true})
+	return d.client.CopyToContainer(context.Background(), id, "/", r, types.CopyToContainerOptions{})
 }
 
 // Flatten copies a tarred up series of files (passed in through the

--- a/builder/verbs.go
+++ b/builder/verbs.go
@@ -345,7 +345,7 @@ func checkCopyArgs(b *Builder, args []*mruby.MrbValue) (string, string, error) {
 	}
 
 	source := filepath.Clean(args[0].String())
-	target := filepath.Clean(args[1].String())
+	target := args[1].String()
 
 	wd, err := os.Getwd()
 	if err != nil {
@@ -370,18 +370,20 @@ func checkCopyArgs(b *Builder, args []*mruby.MrbValue) (string, string, error) {
 		targetWd = workdir.Temporary
 	}
 
-	fi, err := os.Lstat(source)
-	if err != nil {
-		return "", "", err
-	}
-
-	if strings.HasSuffix(target, "/") || fi.IsDir() {
-		target = filepath.Clean(filepath.Join(targetWd, target, rel))
+	// special case .
+	if target == "." {
+		target = filepath.Join(targetWd, filepath.Base(rel))
 	} else {
-		target = filepath.Clean(filepath.Join(targetWd, target))
+		if strings.HasSuffix(target, "/") {
+			target = filepath.Join(target, filepath.Base(rel))
+		}
+
+		if !strings.HasPrefix(target, "/") {
+			target = filepath.Join(targetWd, target)
+		}
 	}
 
-	return rel, target, nil
+	return filepath.Clean(rel), target, nil
 }
 
 func doCopy(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, self *mruby.MrbValue) (mruby.Value, mruby.Value) {

--- a/docs/user-guide/verbs.md
+++ b/docs/user-guide/verbs.md
@@ -280,6 +280,11 @@ the current directory. The build cache is calculated by summing the tar
 result of edited files. Since mtime is also considered, changes to that will
 also bust the cache.
 
+NOTE: copy will not overwrite directories with files, this will abort the run.
+If you are trying to copy a file into a named directory, suffix it with `/`
+which will instruct it to put it into that directory instead of trying to
+replace it with the file you're copying.
+
 NOTE: copy does not respect user permissions when the `user` or `with_user`
 modifiers are applied. This will be fixed eventually.
 
@@ -291,4 +296,6 @@ from "debian"
 # recursively copies everything the cwd to test, which is relative to the
 # workdir inside the container (`/` by default).
 copy ".", "/test"
+
+copy "a_file", "/tmp/" # example of not overwriting directories with files
 ```


### PR DESCRIPTION
Prior to this patch, copying a file over a dir meant that the dir would be
removed, uploading the file in its place.

Now, this aborts the run. To copy the file INTO the dir, specify it with `/` at
the end.

Documentation has also been amended.

Fixes #69 

cc @errordeveloper