### PR TITLE
builder: (temporarily) do not allow copies into volumes

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	. "testing"
 
@@ -108,6 +109,19 @@ func (bs *builderSuite) TestCopyOverDir(c *C) {
     run "test -f /tmp/test1.rb"
   `, testpath))
 	c.Assert(err, IsNil)
+}
+
+func (bs *builderSuite) TestCopyOverVolume(c *C) {
+	// box deliberately does not support image volumes, so we must build from docker first.
+	cmd := exec.Command("docker", "build", "-t", "volumes", "-f", "testdata/dockerfiles/Dockerfile.volumes", ".")
+	out, err := cmd.CombinedOutput()
+	c.Assert(err, IsNil, Commentf("%v", string(out)))
+
+	_, err = runBuilder(`
+  from "volumes"
+  copy ".", "/tmp/"
+  `)
+	c.Assert(err, NotNil)
 }
 
 func (bs *builderSuite) TestCopy(c *C) {

--- a/builder/config/config.go
+++ b/builder/config/config.go
@@ -29,13 +29,15 @@ type Config struct {
 	WorkDir    StringState      // the current working directory on entering a container
 	Cmd        StringSliceState // the secondary execution form, it is provided to images if given to docker run, otherwise this is used.
 	Entrypoint StringSliceState // the primary execution form, the first arguments and the exec() jumping-off point.
-	Env        []string
+	Env        []string         // Environment variables
+	Volumes    []string         // Volume paths
 }
 
 // NewConfig initializes a new configuration.
 func NewConfig() *Config {
 	return &Config{
 		Env:     []string{},
+		Volumes: []string{},
 		User:    StringState{"", "root"},
 		WorkDir: StringState{"", "/"},
 		Image:   "",
@@ -93,6 +95,10 @@ func (c *Config) FromDocker(cont *container.Config) {
 	c.Cmd.Image = cont.Cmd
 	c.User.Image = cont.User
 	c.WorkDir.Image = cont.WorkingDir
+
+	for volume := range cont.Volumes {
+		c.Volumes = append(c.Volumes, volume)
+	}
 
 	if c.User.Image == "" {
 		c.User.Image = "root"

--- a/builder/testdata/dockerfiles/Dockerfile.volumes
+++ b/builder/testdata/dockerfiles/Dockerfile.volumes
@@ -1,0 +1,2 @@
+from debian
+volume /tmp

--- a/builder/verbs.go
+++ b/builder/verbs.go
@@ -392,6 +392,12 @@ func doCopy(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, s
 		return nil, createException(m, err.Error())
 	}
 
+	for _, volume := range b.exec.Config().Volumes {
+		if strings.HasPrefix(target, volume) {
+			return nil, createException(m, fmt.Sprintf("Volume %q cannot be copied into (you tried %q). This is caused by a bug in docker. We are working with docker on a fix.", volume, target))
+		}
+	}
+
 	fn, cacheKey, err := tar.Archive(rel, target)
 	if err != nil {
 		return nil, createException(m, err.Error())


### PR DESCRIPTION
This is a workaround for #55