### PR TITLE
builder: make inside relative to workdir.

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -816,3 +816,45 @@ func (bs *builderSuite) TestExecPropagation(c *C) {
 
 	b.Close()
 }
+
+func (bs *builderSuite) TestInsideRelativeWorkDir(c *C) {
+	_, err := runBuilder(`
+		from "debian"
+		workdir "/etc"
+		inside "apt" do
+			run "ls"
+		end
+	`)
+
+	c.Assert(err, IsNil)
+
+	_, err = runBuilder(`
+		from "debian"
+		inside "/etc" do
+			inside "apt" do
+				run "ls"
+			end
+		end
+	`)
+	c.Assert(err, IsNil)
+
+	// work dir is the default for debian here which is `/`. This should pass.
+	_, err = runBuilder(`
+		from "debian"
+		inside "etc" do
+			inside "apt" do
+				run "ls"
+			end
+		end
+	`)
+	c.Assert(err, IsNil)
+
+	_, err = runBuilder(`
+		from "debian"
+		workdir "/etc"
+		inside "/" do
+			run "cd tmp"
+		end
+	`)
+	c.Assert(err, IsNil)
+}

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -415,7 +415,7 @@ func (bs *builderSuite) TestWorkDirInside(c *C) {
     end
   `)
 
-	c.Assert(err, NotNil)
+	c.Assert(err, IsNil)
 	b.Close()
 
 	b, err = runBuilder(`

--- a/docs/user-guide/verbs.md
+++ b/docs/user-guide/verbs.md
@@ -232,7 +232,13 @@ end
 
 inside, when provided with a directory name string and block, invokes
 commands within the context of the working directory being set to the
-string. It does not affect the final image.
+string.
+
+It will affect the final image if a file-modification event occurs inside a
+directory which has been specified but not created manually yet. This is a side
+effect of the docker engine's relationship to how we use `workdir` directives
+within docker itself. **Docker will create any workdir that does not exist when
+a build container is started.**
 
 Example:
 
@@ -241,6 +247,16 @@ from "debian"
 
 inside "/dev" do
   run "mknod webscale c 1 3"
+end
+```
+
+When given a relative path, it assumes the workdir as well as any other
+additional inside statements. For example:
+
+```ruby
+workdir "/etc"
+inside "apt" do # will travel into /etc/apt/
+  run "rm sources.list"
 end
 ```
 


### PR DESCRIPTION
workdir and inside didn't really cooperate in the sense that they keyed
off each other. Now this works:

```ruby
workdir "/etc"
inside "apt" do
  run "rm sources.list"
end
```

Signed-off-by: Erik Hollensbe <github@hollensbe.org>