### PR TITLE
builder,tar: fix a number of issues with the copy statement.

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -857,4 +857,56 @@ func (bs *builderSuite) TestInsideRelativeWorkDir(c *C) {
 		end
 	`)
 	c.Assert(err, IsNil)
+
+	_, err = runBuilder(`
+		from "debian"
+		workdir "/etc"
+		inside "/" do
+			run "cd tmp"
+		end
+	`)
+	c.Assert(err, IsNil)
+
+	_, err = runBuilder(`
+		from "debian"
+		workdir "/home/erikh"
+		copy ".", "box/"
+	`)
+	c.Assert(err, IsNil)
+
+	_, err = runBuilder(`
+		from "debian"
+		workdir "/home/erikh"
+		copy ".", "box"
+	`)
+	c.Assert(err, IsNil)
+
+	path, err := filepath.Abs("..")
+	c.Assert(err, IsNil)
+
+	defer os.Remove("test")
+	c.Assert(os.Symlink(path, "test"), IsNil)
+
+	_, err = runBuilder(`
+		from "debian"
+		workdir "/home/erikh"
+		copy ".", "box"
+	`)
+	c.Assert(err, NotNil)
+
+	os.Remove("test")
+
+	_, err = runBuilder(`
+		from "debian"
+		workdir "/home/erikh"
+		copy "builder.go", "/builder.go"
+	`)
+	c.Assert(err, IsNil)
+
+	_, err = runBuilder(`
+		from "debian"
+		copy ".", "/go/src/github.com/erikh/box/builder/"
+		run "ls /go/src/github.com/erikh/box/builder/"
+	`)
+	c.Assert(err, IsNil)
 }

--- a/builder/verbs.go
+++ b/builder/verbs.go
@@ -359,7 +359,11 @@ func checkCopyArgs(b *Builder, args []*mruby.MrbValue) (string, string, error) {
 		return "", "", err
 	}
 
-	source := filepath.Clean(args[0].String())
+	source, err := filepath.Abs(args[0].String())
+	if err != nil {
+		return "", "", err
+	}
+
 	target := args[1].String()
 
 	wd, err := os.Getwd()
@@ -367,7 +371,7 @@ func checkCopyArgs(b *Builder, args []*mruby.MrbValue) (string, string, error) {
 		return "", "", err
 	}
 
-	rel, err := filepath.Rel(wd, filepath.Join(wd, source))
+	rel, err := filepath.Rel(wd, source)
 	if err != nil {
 		return "", "", err
 	}
@@ -385,14 +389,10 @@ func checkCopyArgs(b *Builder, args []*mruby.MrbValue) (string, string, error) {
 		targetWd = workdir.Temporary
 	}
 
-	// special case .
+	// special case `.`
 	if target == "." {
-		target = filepath.Join(targetWd, filepath.Base(rel))
+		target = filepath.Join(targetWd, rel)
 	} else {
-		if strings.HasSuffix(target, "/") {
-			target = filepath.Join(target, filepath.Base(rel))
-		}
-
 		if !strings.HasPrefix(target, "/") {
 			target = filepath.Join(targetWd, target)
 		}

--- a/tar/tar_test.go
+++ b/tar/tar_test.go
@@ -86,7 +86,7 @@ func (ts *tarSuite) TestArchiveSpecialFile(c *C) {
 		names = append(names, header.Name)
 	}
 
-	c.Assert(count, Equals, 2, Commentf("%v", names))
+	c.Assert(count, Equals, 3, Commentf("%v", names))
 }
 
 func (ts *tarSuite) TestArchiveGlob(c *C) {


### PR DESCRIPTION
* now, if you supply a relative directory path, it will not rewrite
  symlinks to have an additional path component.
* symlinks are no longer linked to the wrong places, and symlinks are no
  longer capable of following under the working directory.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>