### PR TITLE
builder,repl,main.go: Refactors to support better configuration.

### DIFF
--- a/builder/executor/docker/docker.go
+++ b/builder/executor/docker/docker.go
@@ -105,6 +105,11 @@ func (d *Docker) UseCache(arg bool) {
 	d.useCache = arg
 }
 
+// GetCache gets the current value of whether or not to use the cache
+func (d *Docker) GetCache() bool {
+	return d.useCache
+}
+
 // UseTTY determines whether or not to allow docker to use a TTY for both run
 // and pull operations.
 func (d *Docker) UseTTY(arg bool) {

--- a/builder/executor/executor.go
+++ b/builder/executor/executor.go
@@ -66,6 +66,9 @@ type Executor interface {
 	// UseCache determines if the cache should be considered or not.
 	UseCache(bool)
 
+	// GetCache gets the current value of whether or not to use the cache
+	GetCache() bool
+
 	// UseTTY determines whether or not to allow docker to use a TTY for both run and pull operations.
 	UseTTY(bool)
 

--- a/builder/util_test.go
+++ b/builder/util_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
 
 	. "gopkg.in/check.v1"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func runBuilder(script string) (*Builder, error) {
-	b, err := NewBuilder(term.IsTerminal(0), []string{})
+	b, err := NewBuilder(BuildConfig{Cache: os.Getenv("NO_CACHE") == ""})
 	if err != nil {
 		return nil, err
 	}

--- a/builder/verbs.go
+++ b/builder/verbs.go
@@ -422,7 +422,7 @@ func doCopy(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, s
 
 	cacheKey = fmt.Sprintf("box:copy %s", cacheKey)
 
-	if b.useCache {
+	if b.exec.GetCache() {
 		cached, err := b.exec.CheckCache(cacheKey)
 		if err != nil {
 			return nil, createException(m, err.Error())

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -24,13 +24,19 @@ type Repl struct {
 }
 
 // NewRepl constructs a new Repl.
-func NewRepl() (*Repl, error) {
+func NewRepl(omit []string) (*Repl, error) {
 	rl, err := readline.New(normalPrompt)
 	if err != nil {
 		return nil, err
 	}
 
-	b, err := builder.NewBuilder(true, []string{})
+	fmt.Println(omit)
+
+	b, err := builder.NewBuilder(builder.BuildConfig{
+		OmitFuncs: omit,
+		TTY:       true,
+		Cache:     false,
+	})
 	if err != nil {
 		rl.Close()
 		return nil, err


### PR DESCRIPTION
Additionally some issues with the REPL were fixed:

* The `-o` flag is now respected
* Caching is turned off, which makes the REPL much easier to use.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>