### PR TITLE
multi,main.go,builder: first edition of multi-builder.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
-PACKAGES := ./cli-tests ./builder ./builder/executor/docker ./image ./tar
+PACKAGES := ./cli-tests ./builder ./builder/executor/docker ./image ./tar ./multi
 
 all: checks install
 
-install:
+fetch:
 	cd vendor/github.com/mitchellh/go-mruby && MRUBY_CONFIG=$(shell pwd)/mruby_config.rb make
+
+install: fetch
 	go install -v .
 
 clean:
@@ -17,7 +19,7 @@ bootstrap:
 
 bootstrap-test: bootstrap run-test
 
-checks:
+checks: fetch
 	@sh checks.sh
  
 build:

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -78,12 +78,12 @@ func (bs *builderSuite) TestContext(c *C) {
 	errChan := make(chan error)
 
 	go func() {
-		_, err := b.RunScript(`
+		result := b.RunScript(`
 			from "debian"
 			run "sleep 2"
 			run "ls"
 		`)
-		errChan <- err
+		errChan <- result.Err
 		cancel()
 	}()
 
@@ -95,12 +95,12 @@ func (bs *builderSuite) TestContext(c *C) {
 	c.Assert(err, IsNil)
 
 	go func() {
-		_, err := b.RunScript(`
+		result := b.RunScript(`
 			from "debian"
 			run "sleep 2"
 			run "ls"
 		`)
-		errChan <- err
+		errChan <- result.Err
 	}()
 
 	go func() {

--- a/builder/executor/docker/docker.go
+++ b/builder/executor/docker/docker.go
@@ -21,6 +21,7 @@ import (
 
 // Docker implements an executor that talks to docker to achieve its goals.
 type Docker struct {
+	showRun      bool
 	client       *client.Client
 	config       *config.Config
 	from         string
@@ -38,13 +39,14 @@ type Docker struct {
 
 // NewDocker constructs a new docker instance, for executing against docker
 // engines.
-func NewDocker(ctx context.Context, useCache, tty bool) (*Docker, error) {
+func NewDocker(ctx context.Context, showRun, useCache, tty bool) (*Docker, error) {
 	client, err := client.NewEnvClient()
 	if err != nil {
 		return nil, err
 	}
 
 	return &Docker{
+		showRun:    showRun,
 		tty:        tty,
 		useCache:   useCache,
 		client:     client,

--- a/builder/executor/docker/docker_image_test.go
+++ b/builder/executor/docker/docker_image_test.go
@@ -15,7 +15,7 @@ import (
 func (ds *dockerSuite) TestMakeImage(c *C) {
 	imageName := "ubuntu"
 
-	d, err := NewDocker(context.Background(), true, ds.tty)
+	d, err := NewDocker(context.Background(), true, true, ds.tty)
 	c.Assert(err, IsNil)
 
 	_, err = d.Fetch(imageName)

--- a/builder/executor/docker/docker_run_test.go
+++ b/builder/executor/docker/docker_run_test.go
@@ -16,14 +16,14 @@ func (ds *dockerSuite) TestRunCommit(c *C) {
 		return "", errors.New("an error")
 	}
 
-	d, err := NewDocker(context.Background(), false, false)
+	d, err := NewDocker(context.Background(), true, false, false)
 	c.Assert(err, IsNil)
 	id, err := d.Fetch("debian:latest")
 	c.Assert(err, IsNil)
 	c.Assert(d.Commit("", commit), IsNil)
 	c.Assert(d.config.Image, Not(Equals), id)
 
-	d, err = NewDocker(context.Background(), false, false)
+	d, err = NewDocker(context.Background(), true, false, false)
 	c.Assert(err, IsNil)
 	id, err = d.Fetch("debian:latest")
 	c.Assert(err, IsNil)
@@ -32,7 +32,7 @@ func (ds *dockerSuite) TestRunCommit(c *C) {
 }
 
 func (ds *dockerSuite) TestRunHook(c *C) {
-	d, err := NewDocker(context.Background(), false, false)
+	d, err := NewDocker(context.Background(), true, false, false)
 	c.Assert(err, IsNil)
 	id, err := d.Fetch("debian:latest")
 	c.Assert(err, IsNil)
@@ -42,7 +42,7 @@ func (ds *dockerSuite) TestRunHook(c *C) {
 	c.Assert(d.Commit("test", d.RunHook), IsNil)
 	c.Assert(d.config.Image, Not(Equals), id)
 
-	d, err = NewDocker(context.Background(), false, false)
+	d, err = NewDocker(context.Background(), true, false, false)
 	c.Assert(err, IsNil)
 	id, err = d.Fetch("debian:latest")
 	c.Assert(err, IsNil)

--- a/builder/executor/docker/docker_test.go
+++ b/builder/executor/docker/docker_test.go
@@ -30,7 +30,7 @@ func (ds *dockerSuite) SetUpSuite(c *C) {
 }
 
 func (ds *dockerSuite) clearDockerPrefix(c *C, prefix string) {
-	d, err := NewDocker(context.Background(), true, ds.tty)
+	d, err := NewDocker(context.Background(), true, true, ds.tty)
 	c.Assert(err, IsNil)
 	c.Assert(d.ImageID(), Equals, "")
 	// clear out any stale images
@@ -60,17 +60,17 @@ func (ds *dockerSuite) clearDockerPrefix(c *C, prefix string) {
 }
 
 func (ds *dockerSuite) TestParameters(c *C) {
-	d, err := NewDocker(context.Background(), false, false)
+	d, err := NewDocker(context.Background(), true, false, false)
 	c.Assert(err, IsNil)
 	c.Assert(d.tty, Equals, false)
 	c.Assert(d.useCache, Equals, false)
 
-	d, err = NewDocker(context.Background(), true, true)
+	d, err = NewDocker(context.Background(), true, true, true)
 	c.Assert(err, IsNil)
 	c.Assert(d.tty, Equals, true)
 	c.Assert(d.useCache, Equals, true)
 
-	d, err = NewDocker(context.Background(), false, false)
+	d, err = NewDocker(context.Background(), true, false, false)
 	c.Assert(err, IsNil)
 	d.SetStdin(true)
 	c.Assert(d.stdin, Equals, true)
@@ -81,7 +81,7 @@ func (ds *dockerSuite) TestParameters(c *C) {
 }
 
 func (ds *dockerSuite) TestCreate(c *C) {
-	d, err := NewDocker(context.Background(), false, ds.tty)
+	d, err := NewDocker(context.Background(), true, false, ds.tty)
 	c.Assert(err, IsNil)
 
 	id, err := d.Create()
@@ -95,7 +95,7 @@ func (ds *dockerSuite) TestCreate(c *C) {
 func (ds *dockerSuite) TestCommitCache(c *C) {
 	ds.clearDockerPrefix(c, "asdf")
 
-	d, err := NewDocker(context.Background(), true, ds.tty)
+	d, err := NewDocker(context.Background(), true, true, ds.tty)
 	c.Assert(err, IsNil)
 	c.Assert(d.ImageID(), Equals, "")
 	ok, err := d.CheckCache("asdf")
@@ -109,7 +109,7 @@ func (ds *dockerSuite) TestCommitCache(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)
 
-	d, err = NewDocker(context.Background(), true, ds.tty)
+	d, err = NewDocker(context.Background(), true, true, ds.tty)
 	c.Assert(err, IsNil)
 
 	ok, err = d.CheckCache("asdf")
@@ -123,7 +123,7 @@ func (ds *dockerSuite) TestCommitCache(c *C) {
 	c.Assert(d.Commit("asdf3", nil), IsNil)
 	c.Assert(d.ImageID(), Not(Equals), "")
 
-	d, err = NewDocker(context.Background(), true, ds.tty)
+	d, err = NewDocker(context.Background(), true, true, ds.tty)
 	c.Assert(err, IsNil)
 
 	ok, err = d.CheckCache("asdf")
@@ -137,7 +137,7 @@ func (ds *dockerSuite) TestCommitCache(c *C) {
 }
 
 func (ds *dockerSuite) TestFetch(c *C) {
-	d, err := NewDocker(context.Background(), true, ds.tty)
+	d, err := NewDocker(context.Background(), true, true, ds.tty)
 	c.Assert(err, IsNil)
 
 	id, err := d.Fetch("debian:latest")
@@ -151,7 +151,7 @@ func (ds *dockerSuite) TestFetch(c *C) {
 }
 
 func (ds *dockerSuite) TestCopy(c *C) {
-	d, err := NewDocker(context.Background(), true, ds.tty)
+	d, err := NewDocker(context.Background(), true, true, ds.tty)
 	c.Assert(err, IsNil)
 
 	_, err = d.Fetch("debian:latest")
@@ -199,7 +199,7 @@ func (ds *dockerSuite) TestCopy(c *C) {
 }
 
 func (ds *dockerSuite) TestTag(c *C) {
-	d, err := NewDocker(context.Background(), true, ds.tty)
+	d, err := NewDocker(context.Background(), true, true, ds.tty)
 	c.Assert(err, IsNil)
 
 	// clear old state

--- a/builder/funcs.go
+++ b/builder/funcs.go
@@ -51,12 +51,12 @@ func importFunc(b *Builder, m *mruby.Mrb, self *mruby.MrbValue) (mruby.Value, mr
 		return nil, createException(m, err.Error())
 	}
 
-	val, err := b.RunScript(string(content))
-	if err != nil {
-		return nil, createException(m, err.Error())
+	result := b.RunScript(string(content))
+	if result.Err != nil {
+		return nil, createException(m, result.Err.Error())
 	}
 
-	return val, nil
+	return result.Value, nil
 }
 
 // getenv retrieves a value from the building environment (passed in as string)

--- a/builder/util_test.go
+++ b/builder/util_test.go
@@ -24,8 +24,8 @@ func runBuilder(script string) (*Builder, error) {
 		return nil, err
 	}
 
-	_, err = b.RunScript(script)
-	return b, err
+	result := b.RunScript(script)
+	return b, result.Err
 }
 
 func readContainerFile(c *C, b *Builder, fn string) []byte {

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/pkg/term"
 	"github.com/erikh/box/builder"
 	"github.com/erikh/box/log"
+	"github.com/erikh/box/multi"
 	"github.com/erikh/box/repl"
 	bs "github.com/erikh/box/signal"
 	"github.com/urfave/cli"
@@ -33,14 +34,22 @@ var (
 	Copyright = fmt.Sprintf("(C) %d %s - Licensed under MIT license", time.Now().Year(), Author)
 	// UsageText is the description of how to use the program.
 	UsageText = "box [options] filename"
+
+	signalHandler = bs.NewCancellable()
 )
+
+func init() {
+	signals := make(chan os.Signal, 1)
+	go signalHandler.SignalHandler(signals)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+}
 
 func main() {
 	app := cli.NewApp()
 
 	app.Name = Name
 	app.Email = Email
-	app.Version = "0.3.3"
+	app.Version = Version
 	app.Usage = Usage
 	app.Author = Author
 	app.Copyright = Copyright
@@ -75,6 +84,13 @@ func main() {
 
 	app.Commands = []cli.Command{
 		{
+			Name:        "multi",
+			Action:      runMulti,
+			Description: "Run the multi build functionality; supply multiple plans to build",
+			Usage:       "Run the multi build functionality; supply multiple plans to build",
+			ArgsUsage:   "[filename] [filename]",
+		},
+		{
 			Name:        "repl",
 			Action:      runRepl,
 			Description: "Run the read-eval-print loop to interactively work with box",
@@ -96,11 +112,6 @@ func main() {
 			os.Exit(0)
 		}
 
-		signalHandler := bs.NewCancellable()
-		signals := make(chan os.Signal, 1)
-		go signalHandler.SignalHandler(signals)
-		signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
-
 		args := ctx.Args()
 
 		if len(args) < 1 {
@@ -115,40 +126,34 @@ func main() {
 			tty = ctx.Bool("force-tty")
 		}
 
-		cache := os.Getenv("NO_CACHE") == ""
-		if ctx.Bool("no-cache") {
-			cache = false
-		}
-
 		cancelCtx, cancel := context.WithCancel(context.Background())
 		runChan := make(chan struct{})
-
-		b, err := builder.NewBuilder(builder.BuildConfig{
+		buildConfig := builder.BuildConfig{
+			ShowRun:   true,
 			TTY:       tty,
-			OmitFuncs: ctx.StringSlice("omit"),
-			Cache:     cache,
+			OmitFuncs: ctx.GlobalStringSlice("omit"),
+			Cache:     getCache(ctx),
 			Context:   cancelCtx,
 			Runner:    runChan,
 			FileName:  args[0],
-		})
-
-		signalHandler.AddFunc(cancel)
-		signalHandler.AddRunner(runChan)
-
-		if err != nil {
-			panic(err)
 		}
 
-		defer b.Close()
-
-		response, err := b.Run()
+		b, err := mkBuilder(cancel, buildConfig)
 		if err != nil {
 			log.Error(err)
 			os.Exit(1)
 		}
 
-		if response.String() != "" {
-			log.EvalResponse(response.String())
+		defer b.Close()
+
+		result := b.Run()
+		if result.Err != nil {
+			log.Error(result.Err)
+			os.Exit(1)
+		}
+
+		if result.Value.String() != "" {
+			log.EvalResponse(result.Value.String())
 		}
 
 		tag := ctx.String("tag")
@@ -176,6 +181,55 @@ func main() {
 	}
 }
 
+func runMulti(ctx *cli.Context) {
+	builders := []*builder.Builder{}
+
+	args := ctx.Args()
+	if len(args) < 1 {
+		cli.ShowAppHelp(ctx)
+		log.Error("Please provide a filename to process!")
+		os.Exit(1)
+	}
+
+	for _, filename := range args {
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		runChan := make(chan struct{})
+		buildConfig := builder.BuildConfig{
+			TTY:       true,
+			OmitFuncs: ctx.StringSlice("omit"),
+			Cache:     getCache(ctx),
+			Context:   cancelCtx,
+			Runner:    runChan,
+			FileName:  filename,
+		}
+		signalHandler.AddFunc(cancel)
+		signalHandler.AddRunner(runChan)
+
+		b, err := builder.NewBuilder(buildConfig)
+		if err != nil {
+			log.Error(err)
+			os.Exit(1)
+		}
+		builders = append(builders, b)
+	}
+
+	mb := multi.NewBuilder(builders)
+	mb.Build()
+	if err := mb.Wait(); err != nil {
+		log.Error(err)
+		os.Exit(2)
+	}
+}
+
+func getCache(ctx *cli.Context) bool {
+	cache := os.Getenv("NO_CACHE") == ""
+	if ctx.GlobalBool("no-cache") {
+		cache = false
+	}
+
+	return cache
+}
+
 func runRepl(ctx *cli.Context) {
 	r, err := repl.NewRepl(ctx.GlobalStringSlice("omit"))
 	if err != nil {
@@ -187,4 +241,15 @@ func runRepl(ctx *cli.Context) {
 		log.Error(err)
 		os.Exit(1)
 	}
+}
+
+func mkBuilder(cancel context.CancelFunc, buildConfig builder.BuildConfig) (*builder.Builder, error) {
+	b, err := builder.NewBuilder(buildConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	signalHandler.AddFunc(cancel)
+	signalHandler.AddRunner(buildConfig.Runner)
+	return b, nil
 }

--- a/multi/multi.go
+++ b/multi/multi.go
@@ -1,0 +1,53 @@
+package multi
+
+import (
+	"fmt"
+
+	"github.com/erikh/box/builder"
+	"github.com/erikh/box/log"
+)
+
+// Builder is the entrypoint to the multi-build system. It contains several
+// builders.
+type Builder struct {
+	builders []*builder.Builder
+}
+
+// NewBuilder constructs a *Builder.
+func NewBuilder(builders []*builder.Builder) *Builder {
+	return &Builder{builders: builders}
+}
+
+// Build builds all the builders in parallel.
+func (b *Builder) Build() {
+	for _, br := range b.builders {
+		go br.Run()
+	}
+}
+
+// Wait waits for all builds to complete.
+func (b *Builder) Wait() error {
+	resChan := make(chan builder.BuildResult, len(b.builders))
+
+	for _, br := range b.builders {
+		go func(br *builder.Builder) {
+			resChan <- br.Wait()
+		}(br)
+	}
+
+	var errored bool
+
+	for i := 0; i < len(b.builders); i++ {
+		res := <-resChan
+		if res.Err != nil {
+			errored = true
+			log.Error(fmt.Sprintf("%s: error occurred during plan execution: %v", b.builders[i].FileName(), res.Err))
+		}
+	}
+
+	if errored {
+		return fmt.Errorf("some builds contained errors")
+	}
+
+	return nil
+}

--- a/multi/multi_test.go
+++ b/multi/multi_test.go
@@ -1,0 +1,185 @@
+package multi
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	. "testing"
+
+	"github.com/docker/engine-api/client"
+	"github.com/docker/engine-api/types"
+	"github.com/erikh/box/builder"
+
+	. "gopkg.in/check.v1"
+)
+
+type multiSuite struct{}
+
+var _ = Suite(&multiSuite{})
+
+func TestMulti(t *T) {
+	TestingT(t)
+}
+
+var SuccessPlans = map[int]string{
+	1: `
+	from "debian"
+	cmd "ls"
+	tag "success1"
+	`,
+	2: `
+	from "alpine"
+	entrypoint "/bin/sh"
+	tag "successs2"
+	`,
+	3: `
+	from "ubuntu"
+	workdir "/tmp"
+	tag "success3"
+	`,
+	4: `
+	from "debian"
+	run "rm -rf /tmp/*"
+	tag "success4"
+	`,
+	5: `
+	from "alpine"
+	user "root"
+	tag "success5"
+	`,
+}
+
+var FailPlans = map[int]string{
+	1: `
+	from "debian"
+	run "quux"
+	tag "fail1"
+	`,
+	2: `
+	from "alpine"
+	syntax error
+	tag "fail2"
+	`,
+	3: `
+	from "ubuntu"
+	workdir "/bin"
+	user "nobody"
+	run "touch permission-error"
+	tag "fail3"
+	`,
+	4: `
+	from "debian"
+	run "exit 1"
+	tag "fail4"
+	`,
+	5: `
+	from "quezacoatl"
+	tag "fail5"
+	`,
+}
+
+var dockerClient *client.Client
+
+func (ms *multiSuite) SetUpSuite(c *C) {
+	var err error
+
+	dockerClient, err = client.NewEnvClient()
+	c.Assert(err, IsNil)
+}
+
+func (ms *multiSuite) SetUpTest(c *C) {
+	os.Setenv("NO_CACHE", "1")
+}
+
+func mkPlanDir(dir string, i int) string {
+	return filepath.Join(dir, fmt.Sprintf("%d.rb", i))
+}
+
+func mkPlans(plans map[int]string) string {
+	dir, err := ioutil.TempDir("", "box-plans")
+	if err != nil {
+		panic(err)
+	}
+
+	for i, plan := range plans {
+		if err := ioutil.WriteFile(mkPlanDir(dir, i), []byte(plan), 0666); err != nil {
+			panic(err)
+		}
+	}
+
+	return dir
+}
+
+func mkBuilders(plans map[int]string) []*builder.Builder {
+	dir := mkPlans(plans)
+
+	builders := []*builder.Builder{}
+
+	for i := range plans {
+		b, err := builder.NewBuilder(builder.BuildConfig{
+			Context:  context.Background(),
+			Runner:   make(chan struct{}),
+			Cache:    os.Getenv("NO_CACHE") == "",
+			FileName: mkPlanDir(dir, i),
+		})
+
+		if err != nil {
+			panic(err)
+		}
+
+		builders = append(builders, b)
+	}
+
+	return builders
+}
+
+func (ms *multiSuite) TestBuilderBasic(c *C) {
+	mb := NewBuilder(mkBuilders(SuccessPlans))
+	mb.Build()
+	c.Assert(mb.Wait(), IsNil)
+	images, err := dockerClient.ImageList(context.Background(), types.ImageListOptions{})
+	c.Assert(err, IsNil)
+
+	filtered := []types.Image{}
+
+	for _, img := range images {
+		if strings.HasPrefix(img.RepoTags[0], "success") {
+			filtered = append(filtered, img)
+		}
+	}
+
+	defer func(filtered []types.Image) {
+		for _, img := range filtered {
+			_, err := dockerClient.ImageRemove(context.Background(), img.ID, types.ImageRemoveOptions{Force: true})
+			c.Assert(err, IsNil)
+		}
+	}(filtered)
+
+	c.Assert(len(filtered), Equals, len(SuccessPlans))
+
+	mb = NewBuilder(mkBuilders(FailPlans))
+	mb.Build()
+	c.Assert(mb.Wait(), NotNil)
+	images, err = dockerClient.ImageList(context.Background(), types.ImageListOptions{})
+	c.Assert(err, IsNil)
+
+	filtered = []types.Image{}
+
+	for _, img := range images {
+		if strings.HasPrefix(img.RepoTags[0], "fail") {
+			filtered = append(filtered, img)
+		}
+	}
+
+	defer func(filtered []types.Image) {
+		for _, img := range filtered {
+			_, err := dockerClient.ImageRemove(context.Background(), img.ID, types.ImageRemoveOptions{Force: true})
+			c.Assert(err, IsNil)
+		}
+	}(filtered)
+
+	c.Assert(len(filtered), Equals, 0)
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -72,7 +72,7 @@ func (r *Repl) Loop() error {
 
 	var line string
 	var stackKeep int
-	var val *mruby.MrbValue
+	var result builder.BuildResult
 
 	p := mruby.NewParser(r.builder.Mrb())
 	compileContext := mruby.NewCompileContext(r.builder.Mrb())
@@ -118,16 +118,16 @@ func (r *Repl) Loop() error {
 		r.builder.SetContext(ctx)
 		r.signalHandler.AddFunc(cancel)
 
-		val, stackKeep, err = r.builder.RunCode(p.GenerateCode(), stackKeep)
+		result, stackKeep = r.builder.RunCode(p.GenerateCode(), stackKeep)
 		line = ""
 		r.readline.SetPrompt(normalPrompt)
-		if err != nil {
-			fmt.Printf("+++ Error: %v\n", err)
+		if result.Err != nil {
+			fmt.Printf("+++ Error: %v\n", result.Err)
 			continue
 		}
 
-		if val.String() != "" {
-			fmt.Println(val)
+		if result.Value.String() != "" {
+			fmt.Println(result.Value)
 		}
 	}
 }


### PR DESCRIPTION
Here we go! This is the first edition of the multi-builder, a way to build docker images in parallel.

The initial implementation is a (large) thread safety patch for the builder and the new 'multi' package, which is used to facilitate the multi-building. Then it is linked into the binary via the `multi` command which lets you specify multiple plans.

The UI is still coming and that will be a separate patch.