### PR TITLE
main.go: fix usage documentation (instead of a panic) on invocation without args.

### DIFF
--- a/cli-tests/basic_test.go
+++ b/cli-tests/basic_test.go
@@ -13,6 +13,7 @@ func (s *cliSuite) TestBasic(c *C) {
 	cmd, err := build("", "test.rb")
 	c.Assert(err, IsNil)
 	checkSuccess(c, cmd)
+
 }
 
 func (s *cliSuite) TestCache(c *C) {
@@ -81,6 +82,10 @@ func (s *cliSuite) TestTag(c *C) {
 
 func (s *cliSuite) TestHelp(c *C) {
 	cmd := testcli.Command("box", "--help")
+	cmd.Run()
+	c.Assert(strings.Contains(cmd.Stdout(), "USAGE:"), Equals, true)
+
+	cmd = testcli.Command("box")
 	cmd.Run()
 	c.Assert(strings.Contains(cmd.Stdout(), "USAGE:"), Equals, true)
 }

--- a/main.go
+++ b/main.go
@@ -117,13 +117,15 @@ func main() {
 
 		args := ctx.Args()
 
-		log := logger.New(args[0])
+		log := logger.New("main")
 
 		if len(args) < 1 {
 			cli.ShowAppHelp(ctx)
 			log.Error("Please provide a filename to process!")
 			os.Exit(1)
 		}
+
+		log = logger.New(args[0])
 
 		tty := !ctx.Bool("no-tty")
 


### PR DESCRIPTION
cc @unclejack 