### PR TITLE
build.rb: bump Docker to 1.12.5

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -1,7 +1,7 @@
 from "golang"
 
 skip do
-  DOCKER_VERSION = "1.12.4"
+  DOCKER_VERSION = "1.12.6"
 
   PACKAGES = %w[
     build-essential


### PR DESCRIPTION
This bumps Docker to 1.12.5. This version fixes some bugs introduced by 1.12.4.