### PR TITLE
Do not use ubuntu image

### DIFF
--- a/builder/executor/docker/docker_image_test.go
+++ b/builder/executor/docker/docker_image_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (ds *dockerSuite) TestMakeImage(c *C) {
-	imageName := "ubuntu"
+	imageName := "golang"
 
 	d, err := NewDocker(context.Background(), logger.New(""), true, true, ds.tty)
 	c.Assert(err, IsNil)

--- a/builder/executor/docker/docker_test.go
+++ b/builder/executor/docker/docker_test.go
@@ -34,6 +34,7 @@ func (ds *dockerSuite) SetUpSuite(c *C) {
 	ds.tty = term.IsTerminal(0)
 	dockerClient, err = client.NewEnvClient()
 	c.Assert(err, IsNil)
+	ds.TearDownSuite(c)
 }
 
 func (ds *dockerSuite) TearDownSuite(c *C) {

--- a/multi/multi_test.go
+++ b/multi/multi_test.go
@@ -36,7 +36,7 @@ var SuccessPlans = map[int]string{
 	tag "successs2"
 	`,
 	3: `
-	from "ubuntu"
+	from "golang"
 	workdir "/tmp"
 	tag "success3"
 	`,
@@ -64,7 +64,7 @@ var FailPlans = map[int]string{
 	tag "fail2"
 	`,
 	3: `
-	from "ubuntu"
+	from "golang"
 	workdir "/bin"
 	user "nobody"
 	run "touch permission-error"


### PR DESCRIPTION
This PR eliminates the need for the ubuntu image in the test suite. It was
large and frequently was a part of the no space errors on travis.
