### PR TITLE
Enable post-build hooks

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -1,22 +1,24 @@
 from "golang"
 
+after { tag "erikh/box:master" }
+
+DOCKER_VERSION = "1.12.6"
+
+PACKAGES = %w[
+  build-essential
+  g++
+  git
+  wget
+  curl
+  ruby
+  bison
+  flex
+  iptables
+  psmisc
+  python-pip
+]
+
 skip do
-  DOCKER_VERSION = "1.12.6"
-
-  PACKAGES = %w[
-    build-essential
-    g++
-    git
-    wget
-    curl
-    ruby
-    bison
-    flex
-    iptables
-    psmisc
-    python-pip
-  ]
-
   workdir "/"
   
   qq = getenv("CI_BUILD") != "" ? "-qq" : ""
@@ -42,4 +44,5 @@ skip do
 end
 
 run "mv /go/bin/box /box"
+workdir "/"
 set_exec entrypoint: ["/box"], cmd: []

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -69,6 +69,18 @@ func (bs *builderSuite) TearDownSuite(c *C) {
 	}
 }
 
+func (bs *builderSuite) TestAfter(c *C) {
+	b, err := runBuilder(`
+		from "golang"
+		after { tag "test" }
+	`)
+	c.Assert(err, IsNil)
+	b.Close()
+
+	_, _, err = dockerClient.ImageInspectWithRaw(context.Background(), "test")
+	c.Assert(err, IsNil)
+}
+
 func (bs *builderSuite) TestContext(c *C) {
 	toCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -71,7 +71,7 @@ func (bs *builderSuite) TearDownSuite(c *C) {
 
 func (bs *builderSuite) TestAfter(c *C) {
 	b, err := runBuilder(`
-		from "golang"
+		from "alpine"
 		after { tag "test" }
 	`)
 	c.Assert(err, IsNil)

--- a/builder/verbs.go
+++ b/builder/verbs.go
@@ -28,6 +28,7 @@ type verbDefinition struct {
 
 // verbJumpTable is the dispatch instructions sent to the builder at preparation time.
 var verbJumpTable = map[string]*verbDefinition{
+	"after":      {after, mruby.ArgsBlock()},
 	"debug":      {debug, mruby.ArgsNone()},
 	"flatten":    {flatten, mruby.ArgsNone()},
 	"tag":        {tag, mruby.ArgsReq(1)},
@@ -46,6 +47,16 @@ var verbJumpTable = map[string]*verbDefinition{
 
 // verbFunc is a builder DSL function used to interact with docker.
 type verbFunc func(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, self *mruby.MrbValue) (mruby.Value, mruby.Value)
+
+func after(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, self *mruby.MrbValue) (mruby.Value, mruby.Value) {
+	if len(args) != 1 {
+		return nil, createException(m, "invalid args to after")
+	}
+
+	b.afterFunc = args[0]
+
+	return nil, nil
+}
 
 func debug(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, self *mruby.MrbValue) (mruby.Value, mruby.Value) {
 	var shell string


### PR DESCRIPTION
This enables post build hooks, like so:[

```ruby
from "golang"

after do
  flatten
  tag "test"
end

skip do
  run "ls /"
end
```

This will produce a flattened equivalent to the `golang` image.
