### PR TITLE
Fix tar routines to not warn when copying files (not directories)

### DIFF
--- a/tar/tar.go
+++ b/tar/tar.go
@@ -92,16 +92,7 @@ func expandIncludeList(source string) (string, []string, error) {
 			relFiles = append(relFiles, rel)
 		}
 	} else {
-		rel, err := filepath.Rel(source, files[0])
-		if err != nil {
-			return "", nil, err
-		}
-
-		if strings.HasPrefix(rel, "../") {
-			return "", nil, errors.New("path for file falls below copy root")
-		}
-
-		relFiles = []string{rel}
+		return source, []string{}, nil
 	}
 
 	return source, relFiles, nil


### PR DESCRIPTION
The tar routines would warning via docker/docker/pkg/archive when specifying
files and an includeList (which we primed with just the file). This omits the
includeList creation so the warning does not occur.
