### PR TITLE
Fix release materials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dev.rb
 site
 release-notes.txt
 *.tmp.md
+*.bak

--- a/release/release.sh
+++ b/release/release.sh
@@ -20,7 +20,7 @@ cp $GOPATH/bin/box .
 
 lcuname=$(uname -s | tr LD ld)
 
-sed -i -e "s/Version = .*/Version = \"${1}\"/" main.go
+perl -i.bak -e "s/(\\s+)Version = .*/\\1Version = \"${1}\"/" main.go
 
 make
 


### PR DESCRIPTION
Version in main.go was being edited inappropriately and leaving stale files around on BSD sed.
