### PR TITLE
Disable globbing in copy statements

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -356,6 +356,15 @@ func (bs *builderSuite) TestCopy(c *C) {
 
 	c.Assert(err, NotNil)
 	b.Close()
+
+	b, err = runBuilder(`
+		from "debian"
+		copy "testdata/*", "test"
+		run "test -f testdata/dockerfiles/test1.rb"
+	`)
+
+	c.Assert(err, NotNil)
+	b.Close()
 }
 
 func (bs *builderSuite) TestTag(c *C) {

--- a/builder/copy.go
+++ b/builder/copy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/erikh/box/tar"
@@ -112,6 +113,11 @@ func doCopy(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, s
 	rel, target, ignoreList, err := checkCopyArgs(b, args)
 	if err != nil {
 		return nil, createException(m, err.Error())
+	}
+
+	// FIXME hacky glob detection here
+	if regexp.MustCompile(`[\[?*\]]`).MatchString(rel) {
+		return nil, createException(m, "copy statememnts cannot currently handle glob patterns")
 	}
 
 	list, err := readDockerIgnore()

--- a/docs/user-guide/verbs.md
+++ b/docs/user-guide/verbs.md
@@ -358,6 +358,9 @@ replace it with the file you're copying.
 NOTE: copy does not respect user permissions when the `user` or `with_user`
 modifiers are applied. This will be fixed eventually.
 
+NOTE: copy does not currently support glob metacharacters and will abort if
+they are used.
+
 Example:
 
 ```ruby
@@ -370,8 +373,4 @@ workdir "/tmp", do
 end
 
 copy "a_file", "/tmp/" # example of not overwriting directories with files
-copy "files*", "/var/lib" # example of globbing
-
-# copy all files named `files*`, but ignore the ones that start with `files1*`.
-copy "files*", "/var/lib", ignore_list: ["files1*"] 
 ```


### PR DESCRIPTION
Glob patterns seem to have broken since I introduced the docker code. Since
unfortunately this will be quite commplicated to fix now, I have omitted it
from capability and amended the docs so it can be patched in later.
