### PR TITLE
Upgrade docker client and reference server for testing

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -1,7 +1,7 @@
 from "debian"
 
 after { tag "erikh/box:master" }
-DOCKER_VERSION = "1.12.6"
+DOCKER_VERSION = "1.13.1"
 GOLANG_VERSION = "1.7.4"
 
 PACKAGES = %w[

--- a/release/release.sh
+++ b/release/release.sh
@@ -23,12 +23,21 @@ lcuname=$(uname -s | tr LD ld)
 cp $GOPATH/bin/box .
 gzip -c box > "box-${1}.${lcuname}.gz"
 
+for i in deb rpm
+do
+  fpm -n box -v ${1} -s dir -t ${i} box=/usr/bin/box 
+done
+
 case "$(uname -s)" in
   Darwin)
     sum=$(shasum -a 256 "box-${1}.${lcuname}.gz")
   ;;
   Linux)
-    sum=$(sha256sum "box-${1}.${lcuname}.gz")
+    for i in "box-${1}.${lcuname}.gz" box-${1}-1.x86_64.rpm box_${1}_amd64.deb
+    do
+      innersum=$(sha256sum ${i})
+      sum="${sum}\n${innersum}"
+    done
   ;;
 esac
 


### PR DESCRIPTION
This upgrades the docker client and engine to use the latest, 1.13.1.
