### PR TITLE
builder/executor/docker: fix ID retrieval on pull

### DIFF
--- a/builder/executor/docker/docker.go
+++ b/builder/executor/docker/docker.go
@@ -435,7 +435,9 @@ func (d *Docker) CleanupImages() {
 			}
 			// do not check errors because sometimes, the layers can't be deleted and
 			// we want to ignore that behavior.
-			d.client.ImageRemove(d.context, image, types.ImageRemoveOptions{PruneChildren: true})
+			if _, err := d.client.ImageRemove(d.context, image, types.ImageRemoveOptions{PruneChildren: true}); err != nil {
+				fmt.Println(err)
+			}
 		skip:
 		}
 	}


### PR DESCRIPTION
in some situations, the image id could not be reaped for further pull
operations.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>