### PR TITLE
Restore pull progress meter in from statements

### DIFF
--- a/pull/pull.go
+++ b/pull/pull.go
@@ -80,6 +80,14 @@ func (p *Progress) Process() (string, error) {
 		}
 
 		retval = p.processProgressEntry(unpacked)
+
+		if p.tty {
+			p.Print()
+		}
+	}
+
+	for i := 0; i < len(p.idlist)+1; i++ {
+		fmt.Println()
 	}
 
 	return retval, nil


### PR DESCRIPTION
This is just a patch to fix a regression from the port to containers/image and
earlier refactors.
