### PR TITLE
Fix progress meters, integrate with containers/image

### DIFF
--- a/builder/copy.go
+++ b/builder/copy.go
@@ -135,7 +135,7 @@ func doCopy(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, s
 		}
 	}
 
-	fn, cacheKey, err := tar.Archive(b.config.Context, rel, target, ignoreList)
+	fn, cacheKey, err := tar.Archive(b.config.Context, rel, target, ignoreList, b.Logger)
 	if err != nil {
 		return nil, createException(m, err.Error())
 	}

--- a/builder/executor/docker/docker_test.go
+++ b/builder/executor/docker/docker_test.go
@@ -77,7 +77,7 @@ func (ds *dockerSuite) TestCopy(c *C) {
 	_, err = d.Layers().Fetch(d.config, "debian:latest")
 	c.Assert(err, IsNil)
 
-	file, _, err := bt.Archive(context.Background(), ".", ".", []string{})
+	file, _, err := bt.Archive(context.Background(), ".", ".", []string{}, d.logger)
 	c.Assert(err, IsNil)
 
 	f, err := os.Open(file)

--- a/builder/verbs.go
+++ b/builder/verbs.go
@@ -174,7 +174,7 @@ func flatten(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, 
 	}
 
 	defer os.Remove(f.Name())
-	if err := copy.WithProgress(f, rc, "Downloading image contents to host"); err != nil && err != io.EOF {
+	if err := copy.WithProgress(f, rc, b.Logger, "Downloading image contents to host"); err != nil && err != io.EOF {
 		f.Close()
 		return nil, createException(m, err.Error())
 	}

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 	"github.com/erikh/box/builder/config"
+	"github.com/erikh/box/logger"
 
 	. "gopkg.in/check.v1"
 )
@@ -93,7 +94,7 @@ func (is *imageSuite) TestMake(c *C) {
 		}
 	}
 
-	img, err := Make(config.NewConfig(), merged)
+	img, err := Make(config.NewConfig(), merged, logger.New(""))
 	c.Assert(err, IsNil)
 
 	in, err := os.Open(img)

--- a/layers/docker.go
+++ b/layers/docker.go
@@ -21,6 +21,8 @@ import (
 	"github.com/erikh/box/pull"
 )
 
+const megaByte = 1024 * 1024
+
 // Docker needs a documetnation
 type Docker struct {
 	context      context.Context
@@ -207,7 +209,7 @@ func (d *Docker) downloadImage(from string) (string, error) {
 				fmt.Println()
 			}
 
-			d.logger.Print(fmt.Sprintf("%s: %dMB", strings.SplitN(digest, ":", 2)[1][:12], prog.Offset/(1024*1024)))
+			d.logger.Progress(strings.SplitN(digest, ":", 2)[1][:12], float64(prog.Offset/megaByte))
 			last = digest
 		}
 

--- a/layers/docker_image.go
+++ b/layers/docker_image.go
@@ -40,7 +40,7 @@ func NewDockerImage(context context.Context, imageConfig *ImageConfig) (*DockerI
 // Flatten copies a tarred up series of files (passed in through the
 // io.Reader handle) to the image where they are untarred.
 func (d *DockerImage) Flatten(id string, size int64, tw io.Reader) error {
-	imgName, err := image.Flatten(d.imageConfig.Config, id, size, tw)
+	imgName, err := image.Flatten(d.imageConfig.Config, id, size, tw, d.imageConfig.Logger)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (d *DockerImage) Flatten(id string, size int64, tw io.Reader) error {
 	r, w := io.Pipe()
 
 	go func() {
-		err := copy.WithProgress(w, out, "Loading image into docker")
+		err := copy.WithProgress(w, out, d.imageConfig.Logger, "Loading image into docker")
 		if err != nil {
 			w.CloseWithError(err)
 		} else {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/docker/docker/pkg/term"
 	"github.com/fatih/color"
 )
 
@@ -111,7 +112,7 @@ func (l *Logger) EvalResponse(response string) {
 	line := l.getPlan()
 	line += l.Good("")
 	line += color.New(color.FgWhite, color.Bold).SprintFunc()("Eval Response:")
-	fmt.Fprintln(l.output, line, "", response) // dat whitespace
+	fmt.Fprintln(l.output, line, response)
 	color.Unset()
 }
 
@@ -135,4 +136,29 @@ func (l *Logger) EndOutput() {
 	line := l.getPlan()
 	line += color.New(color.FgRed, color.Bold, color.BgWhite).SprintFunc()("------- END OUTPUT -------")
 	fmt.Fprintln(l.output, line)
+}
+
+// Progress is a representation of a progress meter.
+func (l *Logger) Progress(prefix string, count float64) {
+	out := fmt.Sprint("\r")
+	out += l.getPlan()
+
+	wsz, _ := term.GetWinsize(0)
+
+	mbs := fmt.Sprintf("%.02fMB", count)
+
+	justifiedWidth := int(wsz.Width) - len(mbs) - 9
+	if justifiedWidth < 0 {
+		return
+	}
+
+	out += color.New(color.FgWhite, color.Bold).SprintFunc()("+++ ")
+
+	if len(prefix) > int(justifiedWidth) {
+		prefix = prefix[:int(justifiedWidth)] + "..."
+	}
+
+	out += color.New(color.FgRed, color.Bold).SprintfFunc()("%s: ", prefix)
+	out += color.New(color.FgWhite).SprintFunc()(mbs)
+	fmt.Fprint(l.output, out)
 }

--- a/tar/sum.go
+++ b/tar/sum.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/erikh/box/copy"
+	"github.com/erikh/box/logger"
 )
 
 // SumReader sums an io.Reader
@@ -16,7 +17,7 @@ func SumReader(reader io.Reader) (string, error) {
 }
 
 // SumWithCopy simultaneously sums and copies a stream.
-func SumWithCopy(writer io.WriteCloser, reader io.Reader, fileType string) (string, error) {
+func SumWithCopy(writer io.WriteCloser, reader io.Reader, logger *logger.Logger, fileType string) (string, error) {
 	hashReader, hashWriter := io.Pipe()
 	tarReader := io.TeeReader(reader, hashWriter)
 
@@ -32,7 +33,7 @@ func SumWithCopy(writer io.WriteCloser, reader io.Reader, fileType string) (stri
 		}
 	}()
 
-	if err := copy.WithProgress(writer, tarReader, fileType); err != nil {
+	if err := copy.WithProgress(writer, tarReader, logger, fileType); err != nil {
 		writer.Close()
 		return "", err
 	}

--- a/tar/tar_test.go
+++ b/tar/tar_test.go
@@ -11,12 +11,16 @@ import (
 	"strings"
 	. "testing"
 
+	"github.com/erikh/box/logger"
+
 	"golang.org/x/sys/unix"
 
 	. "gopkg.in/check.v1"
 )
 
 type tarSuite struct{}
+
+var log = logger.New("")
 
 var _ = Suite(&tarSuite{})
 
@@ -25,7 +29,7 @@ func TestTar(t *T) {
 }
 
 func (ts *tarSuite) TestArchive(c *C) {
-	tarball, sum, err := Archive(context.Background(), ".", "/", []string{})
+	tarball, sum, err := Archive(context.Background(), ".", "/", []string{}, log)
 	c.Assert(err, IsNil)
 	c.Assert(sum, Not(Equals), "")
 	c.Assert(tarball, Not(Equals), "")
@@ -58,7 +62,7 @@ func (ts *tarSuite) TestArchiveSpecialFile(c *C) {
 	c.Assert(os.Symlink(tmp.Name(), filepath.Join(dir, "testsym")), IsNil)
 	c.Assert(unix.Mkfifo(filepath.Join(dir, "test.fifo"), 0666), IsNil)
 
-	tarball, _, err := Archive(context.Background(), dir, "/", []string{})
+	tarball, _, err := Archive(context.Background(), dir, "/", []string{}, log)
 	c.Assert(err, IsNil)
 	c.Assert(tarball, Not(Equals), "")
 	defer os.Remove(tarball)
@@ -104,7 +108,7 @@ func (ts *tarSuite) TestArchiveGlob(c *C) {
 	}
 
 	for _, prefix := range prefixes {
-		tarball, _, err := Archive(context.Background(), fmt.Sprintf("%s/%s*", dir, prefix), "/", []string{})
+		tarball, _, err := Archive(context.Background(), fmt.Sprintf("%s/%s*", dir, prefix), "/", []string{}, log)
 		c.Assert(err, IsNil)
 		defer os.Remove(tarball)
 
@@ -143,7 +147,7 @@ func (ts *tarSuite) TestArchiveIgnore(c *C) {
 	}
 
 	for _, prefix := range prefixes {
-		tarball, _, err := Archive(context.Background(), dir, "/", []string{fmt.Sprintf("%s*", prefix)})
+		tarball, _, err := Archive(context.Background(), dir, "/", []string{fmt.Sprintf("%s*", prefix)}, log)
 		c.Assert(err, IsNil)
 		defer os.Remove(tarball)
 
@@ -185,7 +189,7 @@ func (ts *tarSuite) TestUnarchive(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(target)
 
-	tarball, _, err := Archive(context.Background(), dir, "/", []string{})
+	tarball, _, err := Archive(context.Background(), dir, "/", []string{}, log)
 	c.Assert(err, IsNil)
 
 	f, err := os.Open(tarball)


### PR DESCRIPTION
builder,copy,image,layers,logger,tar: Improve progress meters.

This adds the progress meter display code to logger.Logger where it
belongs and integrates it with copy.WithProgress.
