### PR TITLE
build.rb: bump Go to 1.8

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -2,7 +2,7 @@ from "debian"
 
 after { tag "erikh/box:master" }
 DOCKER_VERSION = "1.13.1"
-GOLANG_VERSION = "1.7.4"
+GOLANG_VERSION = "1.8"
 
 PACKAGES = %w[
   build-essential


### PR DESCRIPTION
Go 1.8 includes a lot of fixes and performance improvements. The overhead of calling C functions from Go has been reduced to about half of what it used to be before. The overhead of defer calls has also been lowered to about half.