### PR TITLE
Reorder tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGES := ./cli-tests ./builder ./builder/executor/docker ./layers ./image ./tar ./multi
+PACKAGES := ./cli-tests  ./layers ./image ./tar ./multi ./builder/executor/docker ./builder
 BUILD_TAGS := "btrfs_noversion libdm_no_deferred_remove"
 
 all: checks install


### PR DESCRIPTION
The builder tests in particular are very long and are the first tests run.
This will allow tests that would normally fail later in the cycle to be
able to fail much earlier giving quicker feedback.
