### PR TITLE
Mute docker output in tests

### DIFF
--- a/docker-test.sh
+++ b/docker-test.sh
@@ -1,19 +1,32 @@
 #!/bin/bash	
 
+term() {
+  killall dockerd
+  wait
+}
+
 set -eu
 
 mkdocs build
 
-dockerd -s vfs &
+dockerd -s vfs &>/tmp/docker.log &
 sleep 5
+
+set +e
 
 for i in $*
 do
   DIND=1 go test -cover -timeout 60m -v "$i" -check.v -check.f "${TESTRUN}"
+  if [ $? != 0 ]
+  then
+    status=$?
+    tail -n 100 /tmp/docker.log
+    term
+    exit $status
+  fi
 done
 
-status=$?
+set -e
 
-killall dockerd
-wait
-exit $status
+term
+exit 0


### PR DESCRIPTION
This also fixes some long-standing hanging bugs when the tests terminated
earlier than anticipated.
