### PR TITLE
Refactor signal handling

### DIFF
--- a/builder/verbs.go
+++ b/builder/verbs.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/erikh/box/copy"
+	"github.com/erikh/box/signal"
 	mruby "github.com/mitchellh/go-mruby"
 )
 
@@ -190,6 +191,9 @@ func flatten(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, 
 	if err != nil {
 		return nil, createException(m, err.Error())
 	}
+
+	signal.Handler.AddFile(f.Name())
+	defer signal.Handler.RemoveFile(f.Name())
 
 	defer os.Remove(f.Name())
 	if err := copy.WithProgress(f, rc, b.Logger, "Downloading image contents to host"); err != nil && err != io.EOF {

--- a/image/image.go
+++ b/image/image.go
@@ -15,6 +15,7 @@ import (
 	"github.com/erikh/box/builder/config"
 	"github.com/erikh/box/copy"
 	"github.com/erikh/box/logger"
+	"github.com/erikh/box/signal"
 	bt "github.com/erikh/box/tar"
 )
 
@@ -309,12 +310,18 @@ func Flatten(config *config.Config, id string, size int64, tw io.Reader, logger 
 		return "", err
 	}
 
+	signal.Handler.AddFile(out.Name())
+	defer signal.Handler.RemoveFile(out.Name())
+
 	defer out.Close()
 
 	tf, err := tmpfile()
 	if err != nil {
 		return "", err
 	}
+
+	signal.Handler.AddFile(tf.Name())
+	defer signal.Handler.RemoveFile(tf.Name())
 
 	defer os.Remove(tf.Name())
 

--- a/main.go
+++ b/main.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/docker/docker/pkg/term"
@@ -15,7 +13,7 @@ import (
 	"github.com/erikh/box/logger"
 	"github.com/erikh/box/multi"
 	"github.com/erikh/box/repl"
-	bs "github.com/erikh/box/signal"
+	"github.com/erikh/box/signal"
 	"github.com/urfave/cli"
 )
 
@@ -35,15 +33,7 @@ var (
 	Copyright = fmt.Sprintf("(C) %d %s - Licensed under MIT license", time.Now().Year(), Author)
 	// UsageText is the description of how to use the program.
 	UsageText = "box [options] filename"
-
-	signalHandler = bs.NewCancellable()
 )
-
-func init() {
-	signals := make(chan os.Signal, 1)
-	go signalHandler.SignalHandler(signals)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
-}
 
 func main() {
 	app := cli.NewApp()
@@ -213,8 +203,8 @@ func runMulti(ctx *cli.Context) {
 			Runner:    runChan,
 			FileName:  filename,
 		}
-		signalHandler.AddFunc(cancel)
-		signalHandler.AddRunner(runChan)
+		signal.Handler.AddFunc(cancel)
+		signal.Handler.AddRunner(runChan)
 
 		b, err := builder.NewBuilder(buildConfig)
 		if err != nil {
@@ -261,7 +251,7 @@ func mkBuilder(cancel context.CancelFunc, buildConfig builder.BuildConfig) (*bui
 		return nil, err
 	}
 
-	signalHandler.AddFunc(cancel)
-	signalHandler.AddRunner(buildConfig.Runner)
+	signal.Handler.AddFunc(cancel)
+	signal.Handler.AddRunner(buildConfig.Runner)
 	return b, nil
 }

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -4,8 +4,21 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 )
+
+// Handler is the default registered signal handler. It is created when this
+// package is initialized.
+var Handler = NewCancellable()
+
+func init() {
+	signals := make(chan os.Signal, 1)
+	go Handler.SignalHandler(signals)
+
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+}
 
 // Cancellable is a cancellable process triggered via signal. It will cascade
 // through the context's cancel functions destroying each build process as a

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -28,6 +28,7 @@ type Cancellable struct {
 	IgnoreRunners bool
 
 	mutex       *sync.Mutex
+	files       map[string]struct{}
 	cancelFuncs []context.CancelFunc
 	runners     []chan struct{}
 }
@@ -36,10 +37,25 @@ type Cancellable struct {
 func NewCancellable() *Cancellable {
 	return &Cancellable{
 		Exit:        true,
+		files:       map[string]struct{}{},
 		mutex:       new(sync.Mutex),
 		cancelFuncs: []context.CancelFunc{},
 		runners:     make([]chan struct{}, 0),
 	}
+}
+
+// AddFile adds a temporary filename to be reaped if the action is canceled.
+func (c *Cancellable) AddFile(filename string) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.files[filename] = struct{}{}
+}
+
+// RemoveFile removes a file from the temporary file list.
+func (c *Cancellable) RemoveFile(filename string) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	delete(c.files, filename)
 }
 
 // AddFunc adds a cancel func to the list.
@@ -72,6 +88,16 @@ func (c *Cancellable) SignalHandler(signals chan os.Signal) {
 			for _, runner := range c.runners {
 				<-runner
 			}
+		}
+
+		for fn := range c.files {
+			fmt.Fprintf(os.Stderr, "Cleaning up temporary file %q", fn)
+
+			if err := os.Remove(fn); err != nil {
+				fmt.Fprintf(os.Stderr, ": %v", err)
+			}
+
+			fmt.Fprintln(os.Stderr)
 		}
 
 		if c.Exit {

--- a/tar/archive.go
+++ b/tar/archive.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"github.com/erikh/box/copy"
 	"github.com/erikh/box/logger"
+	"github.com/erikh/box/signal"
 )
 
 // rewriteTar rewrites the tar's paths to copy the source to the target.
@@ -117,6 +118,9 @@ func Archive(ctx context.Context, source, target string, ignoreList []string, lo
 	if err != nil {
 		return "", "", err
 	}
+
+	signal.Handler.AddFile(f.Name())
+	defer signal.Handler.RemoveFile(f.Name())
 
 	tr := tar.NewReader(reader)
 	tw := tar.NewWriter(f)


### PR DESCRIPTION
This makes the signal handler a singleton (for simplicity) and also makes
temporary files amenable to cleanup when handlers fire.
