### PR TITLE
builder: save function

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -407,6 +407,30 @@ func (bs *builderSuite) TestTag(c *C) {
 	b.Close()
 }
 
+func (bs *builderSuite) TestSave(c *C) {
+	b, err := runBuilder(`
+    from "debian"
+		save tag: "test"
+  `)
+
+	c.Assert(err, IsNil)
+	c.Assert(b.exec.Config().Image, Not(Equals), "test")
+
+	inspect, _, err := dockerClient.ImageInspectWithRaw(context.Background(), "test")
+	c.Assert(err, IsNil)
+
+	var found bool
+
+	for _, tag := range inspect.RepoTags {
+		if tag == "test:latest" {
+			found = true
+		}
+	}
+
+	c.Assert(found, Equals, true)
+	b.Close()
+}
+
 func (bs *builderSuite) TestFlatten(c *C) {
 	b, err := runBuilder(`
     from "debian"

--- a/docs/user-guide/functions.md
+++ b/docs/user-guide/functions.md
@@ -4,6 +4,17 @@ your build for further processing; the `read` function allows that.
 
 These are the functions supported by Box.
 
+## save
+
+`save` saves an image. It currently can only tag images at the latest point.
+
+Note this is different than the `tag` verb in that it does not create a new
+layer, potentially dropping configuration elements placed near the end of the
+build. If you are worried about this behavior, please use the `tag` verb.
+
+Note that `save` will also be expanded over time to include new functionality
+such as saving content to files.
+
 ## skip
 
 skip skips all layers within its block in the final produced image, which may


### PR DESCRIPTION
Fixes #165

Note that this new save function does not create a new layer, this is
(forgotten by me) different with the tag verb which does. I may leave the tag
verb alone now because of this and add the save verb which operates slightly
different and will combine parameters to form one function. This is
instrinsically different than tag which just saves a layer to docker.
