### PR TITLE
Fix symlinks in archive routines

### DIFF
--- a/tar/archive.go
+++ b/tar/archive.go
@@ -36,17 +36,6 @@ func rewriteTar(source, target string, logger *logger.Logger, tr *tar.Reader, tw
 			return err
 		}
 
-		if header.Linkname != "" {
-			rel, err := filepath.Rel(header.Linkname, source)
-			if err != nil {
-				return err
-			}
-
-			if strings.HasPrefix(rel, "../") {
-				return fmt.Errorf("path for symlink %q (source: %q) falls below copy root", rel, source)
-			}
-		}
-
 		if (dir || target[len(target)-1] == '/') && header.Name[0] != '/' {
 			// not a single file
 			header.Linkname = path.Join(target, header.Linkname)


### PR DESCRIPTION
tar: remove the limitation on symlinks that fall below the target WD.

This was causing a lot of problems and would make shipping symlinks that
were linked to a lower dir (/etc for example) inside the container. I
think that even though there are some security concerns, this is a
better, more flexible option for users.
