### PR TITLE
Save to file

### DIFF
--- a/builder/funcs.go
+++ b/builder/funcs.go
@@ -43,7 +43,7 @@ func saveFunc(b *Builder, m *mruby.Mrb, self *mruby.MrbValue) (mruby.Value, mrub
 		return nil, createException(m, err.Error())
 	}
 
-	var tag string
+	var tag, file string
 
 	if keys, err := args[0].Hash().Keys(); err != nil || keys.Array().Len() == 0 {
 		return nil, createException(m, "save must be called with parameters")
@@ -53,8 +53,10 @@ func saveFunc(b *Builder, m *mruby.Mrb, self *mruby.MrbValue) (mruby.Value, mrub
 		switch key.String() {
 		case "tag":
 			tag = value.String()
+		case "file":
+			file = value.String()
 		default:
-			return fmt.Errorf("%q is not a valid parameter to save", key.String())
+			return fmt.Errorf("%q is not a valid parameter to the save function", key.String())
 		}
 
 		return nil
@@ -65,6 +67,12 @@ func saveFunc(b *Builder, m *mruby.Mrb, self *mruby.MrbValue) (mruby.Value, mrub
 
 	if tag != "" {
 		if err := b.exec.Image().Tag(tag); err != nil {
+			return nil, createException(m, err.Error())
+		}
+	}
+
+	if file != "" {
+		if err := b.exec.Image().Save(b.ImageID(), file); err != nil {
 			return nil, createException(m, err.Error())
 		}
 	}

--- a/docs/user-guide/functions.md
+++ b/docs/user-guide/functions.md
@@ -6,14 +6,29 @@ These are the functions supported by Box.
 
 ## save
 
-`save` saves an image. It currently can only tag images at the latest point.
+`save` saves an image with parameters:
 
-Note this is different than the `tag` verb in that it does not create a new
-layer, potentially dropping configuration elements placed near the end of the
-build. If you are worried about this behavior, please use the `tag` verb.
+* tag: tag the image in the docker image store. This does not generate a
+  commit, like the `tag` verb does.
+* file: save the image to a file. The resulting file will be a bare tarball
+  with the image contents, suitable for `docker load`.
 
-Note that `save` will also be expanded over time to include new functionality
-such as saving content to files.
+Example:
+
+Tag an image with the name "foo":
+
+```ruby
+from "ubuntu"
+save tag: "foo"
+```
+
+Save the ubuntu image to file after updating it:
+
+```ruby
+from "ubuntu"
+run "apt-get update -qq && apt-get dist-upgrade -y"
+save file: "ubuntu-with-update.tar"
+```
 
 ## skip
 

--- a/layers/types.go
+++ b/layers/types.go
@@ -29,6 +29,9 @@ type Image interface {
 
 	// ImageID returns the image identifier of the most recent layer.
 	ImageID() string
+
+	// Save saves an image to the provided filename.
+	Save(string, string) error
 }
 
 // Layers needs a description


### PR DESCRIPTION
This allows for the saving of images to files. This is critical for initial OCI
support.
