### PR TITLE
build.rb: downgrade Go to 1.7.5

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -2,7 +2,7 @@ from "debian"
 
 after { tag "erikh/box:master" }
 DOCKER_VERSION = "1.13.1"
-GOLANG_VERSION = "1.8"
+GOLANG_VERSION = "1.7.5"
 
 PACKAGES = %w[
   build-essential


### PR DESCRIPTION
This will be needed until Go 1.8.1 is out. I haven't run into any actual issues so far. It's better to stick to 1.7.5 in the meantime.