### PR TITLE
Fix REPL run output

### DIFF
--- a/builder/executor/docker/docker.go
+++ b/builder/executor/docker/docker.go
@@ -103,6 +103,7 @@ func (d *Docker) UseTTY(arg bool) {
 func (d *Docker) SetContext(ctx context.Context) {
 	d.context = ctx
 	d.Layers().SetContext(ctx)
+	d.Image().SetContext(ctx)
 }
 
 // LoadConfig loads the configuration into the executor.

--- a/layers/docker_image.go
+++ b/layers/docker_image.go
@@ -44,6 +44,12 @@ func NewDockerImage(context context.Context, imageConfig *ImageConfig) (*DockerI
 		context:     context,
 	}, nil
 }
+
+// SetContext sets the current context for execution
+func (d *DockerImage) SetContext(ctx context.Context) {
+	d.context = ctx
+}
+
 func (d *DockerImage) ociSave(filename, tag string) error {
 	ref, err := daemon.ParseReference(d.imageConfig.Config.Image)
 	if err != nil {

--- a/layers/types.go
+++ b/layers/types.go
@@ -10,6 +10,9 @@ import (
 
 // Image needs a description
 type Image interface {
+	// SetContext sets the context for upcoming operations.
+	SetContext(context.Context)
+
 	// Flatten copies a tarred up series of files (passed in through the
 	// io.Reader handle) to the image where they are untarred. The first argument
 	// is the parent image to use.

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -41,6 +41,7 @@ func NewRepl(omit []string) (*Repl, error) {
 		TTY:       true,
 		Cache:     false,
 		Context:   ctx,
+		ShowRun:   true,
 	})
 
 	if err != nil {


### PR DESCRIPTION
Currently, run statements do not echo output when running in the repl due to an
architectural change in 0.4. This patch fixes that.
