### PR TITLE
Makefile,build.rb,release: Convert to static build, move away from OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ site
 release-notes.txt
 *.tmp.md
 *.bak
+bin
+portable.sh

--- a/build.rb
+++ b/build.rb
@@ -3,8 +3,12 @@ from "debian"
 after { tag "erikh/box:master" }
 DOCKER_VERSION = "1.13.1"
 GOLANG_VERSION = "1.7.5"
+LVM2_VERSION = "2.02.103"
 
 PACKAGES = %w[
+  libgpg-error-dev
+  libassuan-dev
+  btrfs-tools
   build-essential
   g++
   git
@@ -17,17 +21,32 @@ PACKAGES = %w[
   psmisc
   python2.7
   btrfs-tools
-  libdevmapper-dev
-  libgpgme11-dev
 ]
+
+qq = getenv("CI_BUILD") != "" ? "-qq" : ""
 
 skip do
   workdir "/"
-  
-  qq = getenv("CI_BUILD") != "" ? "-qq" : ""
 
   run "apt-get update #{qq}"
   run "apt-get install -y #{qq} #{PACKAGES.join(" ")}"
+
+	run "mkdir -p /usr/local/gpgme && curl -sSL https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-1.8.0.tar.bz2 | tar -xjC /usr/local/gpgme --strip-components=1"
+	run "cd /usr/local/gpgme && ./configure --enable-static && PREFIX=/usr make install"
+
+	# shamelessly taken from docker
+	run %Q[mkdir -p /usr/local/lvm2 \
+		&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.#{LVM2_VERSION}.tgz" \
+			| tar -xzC /usr/local/lvm2 --strip-components=1]
+	# See https://git.fedorahosted.org/cgit/lvm2.git/refs/tags for release tags
+
+	# Compile and install lvm2
+	run %q[cd /usr/local/lvm2 \
+		&& ./configure \
+			--build="$(gcc -print-multiarch)" \
+			--enable-static_link \
+		&& make device-mapper \
+		&& make install_device-mapper]
 
   docker_path = "docker-#{DOCKER_VERSION}.tgz"
   run "wget -q https://get.docker.com/builds/Linux/x86_64/#{docker_path}"
@@ -44,7 +63,7 @@ skip do
 
   env "PATH" => "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/local/go/bin:/go/bin", "GOPATH" => "/go"
   copy ".", "/go/src/github.com/erikh/box"
-  run "cd /go/src/github.com/erikh/box && make clean install"
+  run "cd /go/src/github.com/erikh/box && VERSION=#{getenv("VERSION")} make clean install-static"
 
   workdir "/go/src/github.com/erikh/box"
   set_exec entrypoint: ["/dind"], cmd: %w[make docker-test]

--- a/docker-test.sh
+++ b/docker-test.sh
@@ -16,5 +16,5 @@ trap term INT TERM
 
 for i in $*
 do
-  DIND=1 go test -cover -timeout 120m -v "$i" -check.v -check.f "${TESTRUN}"
+  DIND=1 go test -tags "btrfs_noversion libdm_no_deferred_remove" -ldflags=-extldflags=-static -cover -timeout 120m -v "$i" -check.v -check.f "${TESTRUN}"
 done

--- a/portable.sh.tmpl
+++ b/portable.sh.tmpl
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec docker run -it -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:$PWD -w $PWD erikh/box:@@VERSION@@ $*


### PR DESCRIPTION
This modifies the build to no longer template `main.go`, leveraging ldflags
to both set the version and build static binaries. This allows
cross-distribution packaging and allows us to deliver a more complete
experience in the docker image, which OS X needs now that we're bound to
linux dependencies.
