### PR TITLE
Fix a test that was failing for the wrong reasons

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -202,9 +202,18 @@ func (bs *builderSuite) TestCopyWithGlob(c *C) {
     copy "*", "."
     run "test -f /test/config/config.go"
 		run "test -f /test/builder.go"
-		run "test -f /test/* || exit 0"
   `)
 	c.Assert(err, IsNil)
+	b.Close()
+
+	b, err = runBuilder(`
+    from "debian"
+    run "mkdir /test"
+    workdir "/test"
+    copy "*", "."
+		run "test -f /test/\\*"
+	`)
+	c.Assert(err, NotNil)
 	b.Close()
 }
 


### PR DESCRIPTION
This test was testing for the presence of a file named `*` which was
errorneously expanding in the shell, causing an error which allowed the test to
succeed, but for the wrong reasons.
