### PR TITLE
Increase test timeout

### DIFF
--- a/docker-test.sh
+++ b/docker-test.sh
@@ -12,21 +12,9 @@ mkdocs build
 dockerd -s vfs &>/tmp/docker.log &
 sleep 5
 
-set +e
+trap term INT TERM
 
 for i in $*
 do
-  DIND=1 go test -cover -timeout 60m -v "$i" -check.v -check.f "${TESTRUN}"
-  if [ $? != 0 ]
-  then
-    status=$?
-    tail -n 100 /tmp/docker.log
-    term
-    exit $status
-  fi
+  DIND=1 go test -cover -timeout 120m -v "$i" -check.v -check.f "${TESTRUN}"
 done
-
-set -e
-
-term
-exit 0


### PR DESCRIPTION
Timeouts were not affecting the build process properly, not exiting
non-zero. Additionally the timeout needed to be increased now that
tests take longer.
