### PR TITLE
Fix non-tty output

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -29,7 +29,7 @@ func Docker(context context.Context, logger *logger.Logger, client *client.Clien
 				return "", nil, err
 			}
 
-			fmt.Println("done.")
+			fmt.Fprintln(logger.Output(), "done.")
 		} else {
 			pull.NewProgress(tty, reader).Process()
 		}

--- a/layers/docker.go
+++ b/layers/docker.go
@@ -148,9 +148,9 @@ func (d *Docker) consumeEdits(progressChan chan ctypes.ProgressProperties) {
 			digest := prog.Artifact.Digest.String()
 
 			if digest == last {
-				fmt.Print("\r")
+				fmt.Fprint(d.logger.Output(), "\r")
 			} else if last != "" {
-				fmt.Println()
+				fmt.Fprintln(d.logger.Output())
 			}
 
 			d.logger.Progress(strings.SplitN(digest, ":", 2)[1][:12], float64(prog.Offset/megaByte))
@@ -159,7 +159,7 @@ func (d *Docker) consumeEdits(progressChan chan ctypes.ProgressProperties) {
 	}
 
 	if d.tty {
-		fmt.Println()
+		fmt.Fprintln(d.logger.Output())
 	}
 }
 
@@ -224,7 +224,7 @@ func (d *Docker) makeImage(from string) (string, error) {
 	}
 
 	if !d.tty {
-		fmt.Println("done.")
+		fmt.Fprintln(d.logger.Output(), "done.")
 	}
 
 	return img2.ConfigInfo().Digest.String(), nil

--- a/layers/docker.go
+++ b/layers/docker.go
@@ -141,6 +141,28 @@ func (d *Docker) calculateCommits(layers []*image.Layer) []*image.Layer {
 	return commitLayers
 }
 
+func (d *Docker) consumeEdits(progressChan chan ctypes.ProgressProperties) {
+	var last string
+	for prog := range progressChan {
+		if d.tty {
+			digest := prog.Artifact.Digest.String()
+
+			if digest == last {
+				fmt.Print("\r")
+			} else if last != "" {
+				fmt.Println()
+			}
+
+			d.logger.Progress(strings.SplitN(digest, ":", 2)[1][:12], float64(prog.Offset/megaByte))
+			last = digest
+		}
+	}
+
+	if d.tty {
+		fmt.Println()
+	}
+}
+
 func (d *Docker) makeImage(from string) (string, error) {
 	ref, err := daemon.ParseReference(from)
 	if err != nil {
@@ -173,25 +195,13 @@ func (d *Docker) makeImage(from string) (string, error) {
 
 	progressChan := make(chan ctypes.ProgressProperties)
 
-	go func() {
-		var last string
-		for prog := range progressChan {
-			digest := prog.Artifact.Digest.String()
+	go d.consumeEdits(progressChan)
 
-			if digest == last {
-				fmt.Print("\r")
-			} else if last != "" {
-				fmt.Println()
-			}
-
-			d.logger.Progress(strings.SplitN(digest, ":", 2)[1][:12], float64(prog.Offset/megaByte))
-			last = digest
-		}
-
-		fmt.Println()
-	}()
-
-	d.logger.Print(d.logger.Notice("Editing image\n"))
+	if d.tty {
+		d.logger.Print(d.logger.Notice("Editing image\n"))
+	} else {
+		d.logger.Print(d.logger.Notice("Editing image..."))
+	}
 
 	img2, err := copy.Image(pc, tgt, ref, &copy.Options{
 		RemoveSignatures: true,
@@ -211,6 +221,10 @@ func (d *Docker) makeImage(from string) (string, error) {
 	close(progressChan)
 	if err != nil {
 		return "", err
+	}
+
+	if !d.tty {
+		fmt.Println("done.")
 	}
 
 	return img2.ConfigInfo().Digest.String(), nil

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -33,8 +33,8 @@ func (l *Logger) Record() {
 }
 
 // Output returns the output buffer.
-func (l *Logger) Output() *bytes.Buffer {
-	return l.buffer
+func (l *Logger) Output() io.Writer {
+	return l.output
 }
 
 // Print is a bare-bones print statement.

--- a/multi/multi_test.go
+++ b/multi/multi_test.go
@@ -1,6 +1,7 @@
 package multi
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -213,7 +214,7 @@ func (ms *multiSuite) TestMultiFrom(c *C) {
 	var found bool
 
 	for _, b := range mb.builders {
-		if strings.Contains(b.Logger.Output().String(), fmt.Sprintf("Pulling %q", imageName)) {
+		if strings.Contains(b.Logger.Output().(*bytes.Buffer).String(), fmt.Sprintf("Pulling %q", imageName)) {
 			if found {
 				c.Fatal("Found two pulls")
 			}


### PR DESCRIPTION
This contains a few fixes for situations where the tty is not present:

* Editing would output numerous newlines when in non-tty mode
* Output writing was not all going through the logger, which made testing output harder.

