### PR TITLE
Make logger trim to terminal size by default

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -71,7 +71,7 @@ func NewBuilder(bc BuildConfig) (*Builder, error) {
 	log := bc.Logger
 
 	if log == nil {
-		log = logger.New(bc.FileName)
+		log = logger.New(bc.FileName, true)
 	}
 
 	exec, err := NewExecutor(bc.Context, "docker", log, bc.ShowRun, bc.Cache, bc.TTY)

--- a/builder/executor/docker/docker_run_test.go
+++ b/builder/executor/docker/docker_run_test.go
@@ -18,14 +18,14 @@ func (ds *dockerSuite) TestRunCommit(c *C) {
 		return "", errors.New("an error")
 	}
 
-	d, err := NewDocker(context.Background(), logger.New(""), true, false, false)
+	d, err := NewDocker(context.Background(), logger.New("", false), true, false, false)
 	c.Assert(err, IsNil)
 	id, err := d.Layers().Fetch(d.config, "debian:latest")
 	c.Assert(err, IsNil)
 	c.Assert(d.Commit("", commit), IsNil)
 	c.Assert(d.config.Image, Not(Equals), id)
 
-	d, err = NewDocker(context.Background(), logger.New(""), true, false, false)
+	d, err = NewDocker(context.Background(), logger.New("", false), true, false, false)
 	c.Assert(err, IsNil)
 	id, err = d.Layers().Fetch(d.config, "debian:latest")
 	c.Assert(err, IsNil)
@@ -34,7 +34,7 @@ func (ds *dockerSuite) TestRunCommit(c *C) {
 }
 
 func (ds *dockerSuite) TestRunHook(c *C) {
-	d, err := NewDocker(context.Background(), logger.New(""), true, false, false)
+	d, err := NewDocker(context.Background(), logger.New("", false), true, false, false)
 	c.Assert(err, IsNil)
 	id, err := d.Layers().Fetch(d.config, "debian:latest")
 	c.Assert(err, IsNil)
@@ -44,7 +44,7 @@ func (ds *dockerSuite) TestRunHook(c *C) {
 	c.Assert(d.Commit("test", d.RunHook), IsNil)
 	c.Assert(d.config.Image, Not(Equals), id)
 
-	d, err = NewDocker(context.Background(), logger.New(""), true, false, false)
+	d, err = NewDocker(context.Background(), logger.New("", false), true, false, false)
 	c.Assert(err, IsNil)
 	id, err = d.Layers().Fetch(d.config, "debian:latest")
 	c.Assert(err, IsNil)

--- a/builder/executor/docker/docker_test.go
+++ b/builder/executor/docker/docker_test.go
@@ -59,7 +59,7 @@ func (ds *dockerSuite) TearDownSuite(c *C) {
 }
 
 func (ds *dockerSuite) TestCreate(c *C) {
-	d, err := NewDocker(context.Background(), logger.New(""), true, false, ds.tty)
+	d, err := NewDocker(context.Background(), logger.New("", false), true, false, ds.tty)
 	c.Assert(err, IsNil)
 
 	id, err := d.Create()
@@ -71,7 +71,7 @@ func (ds *dockerSuite) TestCreate(c *C) {
 }
 
 func (ds *dockerSuite) TestCopy(c *C) {
-	d, err := NewDocker(context.Background(), logger.New(""), true, true, ds.tty)
+	d, err := NewDocker(context.Background(), logger.New("", false), true, true, ds.tty)
 	c.Assert(err, IsNil)
 
 	_, err = d.Layers().Fetch(d.config, "debian:latest")
@@ -119,7 +119,7 @@ func (ds *dockerSuite) TestCopy(c *C) {
 func (ds *dockerSuite) TestCommitCache(c *C) {
 	ds.clearDockerPrefix(c, "asdf")
 
-	d, err := NewDocker(context.Background(), logger.New(""), true, true, ds.tty)
+	d, err := NewDocker(context.Background(), logger.New("", false), true, true, ds.tty)
 	c.Assert(err, IsNil)
 	c.Assert(d.Image().ImageID(), Equals, "")
 	ok, err := d.Image().CheckCache("asdf")
@@ -133,7 +133,7 @@ func (ds *dockerSuite) TestCommitCache(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)
 
-	d, err = NewDocker(context.Background(), logger.New(""), true, true, ds.tty)
+	d, err = NewDocker(context.Background(), logger.New("", false), true, true, ds.tty)
 	c.Assert(err, IsNil)
 
 	ok, err = d.Image().CheckCache("asdf")
@@ -147,7 +147,7 @@ func (ds *dockerSuite) TestCommitCache(c *C) {
 	c.Assert(d.Commit("asdf3", nil), IsNil)
 	c.Assert(d.Image().ImageID(), Not(Equals), "")
 
-	d, err = NewDocker(context.Background(), logger.New(""), true, true, ds.tty)
+	d, err = NewDocker(context.Background(), logger.New("", false), true, true, ds.tty)
 	c.Assert(err, IsNil)
 
 	ok, err = d.Image().CheckCache("asdf")
@@ -161,7 +161,7 @@ func (ds *dockerSuite) TestCommitCache(c *C) {
 }
 
 func (ds *dockerSuite) clearDockerPrefix(c *C, prefix string) {
-	d, err := NewDocker(context.Background(), logger.New(""), true, true, ds.tty)
+	d, err := NewDocker(context.Background(), logger.New("", false), true, true, ds.tty)
 	c.Assert(err, IsNil)
 	c.Assert(d.Image().ImageID(), Equals, "")
 	// clear out any stale images
@@ -191,17 +191,17 @@ func (ds *dockerSuite) clearDockerPrefix(c *C, prefix string) {
 }
 
 func (ds *dockerSuite) TestParameters(c *C) {
-	d, err := NewDocker(context.Background(), logger.New(""), true, false, false)
+	d, err := NewDocker(context.Background(), logger.New("", false), true, false, false)
 	c.Assert(err, IsNil)
 	c.Assert(d.tty, Equals, false)
 	c.Assert(d.Image().GetCache(), Equals, false)
 
-	d, err = NewDocker(context.Background(), logger.New(""), true, true, true)
+	d, err = NewDocker(context.Background(), logger.New("", false), true, true, true)
 	c.Assert(err, IsNil)
 	c.Assert(d.tty, Equals, true)
 	c.Assert(d.Image().GetCache(), Equals, true)
 
-	d, err = NewDocker(context.Background(), logger.New(""), true, false, false)
+	d, err = NewDocker(context.Background(), logger.New("", false), true, false, false)
 	c.Assert(err, IsNil)
 	d.SetStdin(true)
 	c.Assert(d.stdin, Equals, true)

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -72,3 +72,9 @@ No TTY mode is the default when unix pipes are involved.
 Force the TTY on even if it is off for some reason.
 
 The combination of `--no-tty --force-tty` is to force the tty.
+
+## --no-trim
+
+By default, box trims output to the width of the current terminal (unless 
+there is no terminal). This boolean option prevents that behavior, causing box
+to print the complete output.

--- a/image/image.go
+++ b/image/image.go
@@ -75,7 +75,7 @@ func extractLayers(img *imageInfo, dir, file string) error {
 				return err
 			}
 
-			sum, err := bt.SumWithCopy(out, tr, logger.New(layerID[:12]), fmt.Sprintf("Unpacking Layer ID %s", layerID[:12]))
+			sum, err := bt.SumWithCopy(out, tr, logger.New(layerID[:12], false), fmt.Sprintf("Unpacking Layer ID %s", layerID[:12]))
 			if err != nil {
 				return err
 			}

--- a/layers/docker_test.go
+++ b/layers/docker_test.go
@@ -64,7 +64,7 @@ func (ds *dockerSuite) TearDownSuite(c *C) {
 func (ds *dockerSuite) TestLookup(c *C) {
 	imageName := "alpine"
 
-	d, err := NewDocker(context.Background(), ds.tty, logger.New(""))
+	d, err := NewDocker(context.Background(), ds.tty, logger.New("", false))
 	c.Assert(err, IsNil)
 
 	// XXX ok if this call fails
@@ -86,7 +86,7 @@ func (ds *dockerSuite) TestLookup(c *C) {
 func (ds *dockerSuite) TestMakeImage(c *C) {
 	imageName := "postgres"
 
-	d, err := NewDocker(context.Background(), ds.tty, logger.New(""))
+	d, err := NewDocker(context.Background(), ds.tty, logger.New("", false))
 	c.Assert(err, IsNil)
 
 	_, err = d.Fetch(ds.config, imageName)
@@ -174,7 +174,7 @@ func (ds *dockerSuite) TestMakeImage(c *C) {
 }
 
 func (ds *dockerSuite) TestFetch(c *C) {
-	d, err := NewDocker(context.Background(), ds.tty, logger.New(""))
+	d, err := NewDocker(context.Background(), ds.tty, logger.New("", false))
 	c.Assert(err, IsNil)
 
 	id, err := d.Fetch(ds.config, "debian:latest")

--- a/main.go
+++ b/main.go
@@ -71,6 +71,10 @@ func main() {
 			Name:  "omit, o",
 			Usage: "Omit functions/verbs. One per option, repeatable.",
 		},
+		cli.BoolFlag{
+			Name:  "no-trim",
+			Usage: "Do not trim the output to terminal width.",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -97,9 +101,10 @@ func main() {
 		},
 	}
 
-	log := logger.New("main")
-
 	app.Action = func(ctx *cli.Context) {
+		notrim := ctx.Bool("no-trim")
+		log := logger.New("main", notrim)
+
 		if ctx.Bool("help") {
 			cli.ShowAppHelp(ctx)
 			os.Exit(0)
@@ -107,15 +112,11 @@ func main() {
 
 		args := ctx.Args()
 
-		log := logger.New("main")
-
 		if len(args) < 1 {
 			cli.ShowAppHelp(ctx)
 			log.Error("Please provide a filename to process!")
 			os.Exit(1)
 		}
-
-		log = logger.New(args[0])
 
 		tty := !ctx.Bool("no-tty")
 
@@ -133,6 +134,7 @@ func main() {
 			Context:   cancelCtx,
 			Runner:    runChan,
 			FileName:  args[0],
+			Logger:    logger.New(args[0], notrim),
 		}
 
 		b, err := mkBuilder(cancel, buildConfig)
@@ -173,16 +175,16 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		log.Error(err)
+		logger.New("main", false).Error(err)
 		os.Exit(1)
 	}
 }
 
 func runMulti(ctx *cli.Context) {
 	copy.NoOut = true
-
+	notrim := ctx.Bool("no-trim")
 	builders := []*builder.Builder{}
-	log := logger.New("main")
+	log := logger.New("main", notrim)
 
 	args := ctx.Args()
 	if len(args) < 1 {
@@ -202,6 +204,7 @@ func runMulti(ctx *cli.Context) {
 			Context:   cancelCtx,
 			Runner:    runChan,
 			FileName:  filename,
+			Logger:    logger.New(filename, notrim),
 		}
 		signal.Handler.AddFunc(cancel)
 		signal.Handler.AddRunner(runChan)
@@ -232,8 +235,8 @@ func getCache(ctx *cli.Context) bool {
 }
 
 func runRepl(ctx *cli.Context) {
-	log := logger.New("repl")
-	r, err := repl.NewRepl(ctx.GlobalStringSlice("omit"))
+	log := logger.New("repl", ctx.Bool("no-trim"))
+	r, err := repl.NewRepl(ctx.GlobalStringSlice("omit"), log)
 	if err != nil {
 		log.Error(fmt.Sprintf("bootstrapping repl: %v\n", err))
 		os.Exit(1)

--- a/multi/multi.go
+++ b/multi/multi.go
@@ -27,7 +27,7 @@ func (b *Builder) Build() {
 
 // Wait waits for all builds to complete.
 func (b *Builder) Wait() error {
-	log := logger.New("multi")
+	log := logger.New("multi", false)
 
 	resChan := make(chan builder.BuildResult, len(b.builders))
 

--- a/multi/multi_test.go
+++ b/multi/multi_test.go
@@ -122,7 +122,7 @@ func mkBuilders(plans map[int]string) []*builder.Builder {
 	builders := []*builder.Builder{}
 
 	for i := range plans {
-		l := logger.New("")
+		l := logger.New("", false)
 		l.Record()
 
 		b, err := builder.NewBuilder(builder.BuildConfig{

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/chzyer/readline"
 	"github.com/erikh/box/builder"
+	"github.com/erikh/box/logger"
 	"github.com/erikh/box/signal"
 	mruby "github.com/mitchellh/go-mruby"
 )
@@ -26,7 +27,7 @@ type Repl struct {
 }
 
 // NewRepl constructs a new Repl.
-func NewRepl(omit []string) (*Repl, error) {
+func NewRepl(omit []string, log *logger.Logger) (*Repl, error) {
 	rl, err := readline.New(normalPrompt)
 	if err != nil {
 		return nil, err
@@ -42,6 +43,7 @@ func NewRepl(omit []string) (*Repl, error) {
 		Cache:     false,
 		Context:   ctx,
 		ShowRun:   true,
+		Logger:    log,
 	})
 
 	if err != nil {

--- a/tar/tar_test.go
+++ b/tar/tar_test.go
@@ -20,7 +20,7 @@ import (
 
 type tarSuite struct{}
 
-var log = logger.New("")
+var log = logger.New("", false)
 
 var _ = Suite(&tarSuite{})
 


### PR DESCRIPTION
Option --no-trim to get "full" output

Signed-off-by: Christopher Maujean <christopher@maujean.org>

closes #197